### PR TITLE
Ignore all files except the license and dist/ folder when installing with Bower.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,11 +13,10 @@
   ],
   "license": "MIT",
   "ignore": [
-    "**/.*",
-    "node_modules",
-    "vendor",
-    "test",
-    "tests"
+    "*",
+    "!dist/",
+    "!dist/*",
+    "!LICENSE"
   ],
   "devDependencies": {
     "jasmine": "~2.0.4",


### PR DESCRIPTION
When installing mermaid via Bower it still pulls in the majority of the repository, I've proposed a change to only include the license file and the compiled source files in the dist/ folder when installing via Bower.