### PR TITLE
Allow other forms of node selection for init()

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -60,7 +60,12 @@ var parse = function(text){
  *
  * The function tags the processed attributes with the attribute data-processed and ignores found elements with the
  * attribute already set. This way the init function can be triggered several times.
- *
+ * 
+ * Optionally, `init` can accept in the second argument one of the following:
+ * - a DOM Node
+ * - an array of DOM nodes (as would come from a jQuery selector)
+ * - a W3C selector, a la `.mermaid`
+ * 
  * ```
  * graph LR;
  *  a(Find elements)-->b{Processed};
@@ -68,7 +73,12 @@ var parse = function(text){
  *  c-->|No |d(Transform);
  * ```
  */
-var init = function (sequenceConfig) {
+var init = function (sequenceConfig, arr) {
+    arr = arr == null ? document.querySelectorAll('.mermaid')
+      : typeof arr === "string" ? document.querySelectorAll(arr)
+      : arr instanceof Node ? [arr]
+      : arr;
+
     var arr = document.querySelectorAll('.mermaid');
     var i;
     


### PR DESCRIPTION
The existing behavior of init will always re-render the whole page, and requires that a chart be classed `mermaid`.

This change allows the user to specify:
- a DOM Node (as from getQuerySelector)
- a DOM NodeList  (as from getQuerySelectorAll)
- an array of nodes (as from jQuery.find)
- a string (to be handed to getQuerySelectorAll)

As suggested in #37.

Again, can add tests if desired.