### PR TITLE
IE, local html, cssRules access is denied

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -66,7 +66,9 @@ module.exports.cloneCssStyles = function(svg, classes){
             catch(err) {
                 if(typeof console !== 'undefined'){
                     if(console.warn !== 'undefined'){
-                        console.warn('Invalid CSS selector "' + rule.selectorText + '"', err);
+                        if(rule !== 'undefined'){
+                            console.warn('Invalid CSS selector "' + rule.selectorText + '"', err);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
IE, open html file directly from hard disk(insead of from a http server), cssRules access is denied.

Thus an expection is thrown. But in the catch statement, another one is thrown again thus cause the whole mermaid code break. 

In this line `console.warn('Invalid CSS selector "' + rule.selectorText + '"', err);`  rule is undefined, so exception will be thrown if we don't check.