### PR TITLE
Default style when using the CLI

### DIFF
--- a/dist/mermaid.css
+++ b/dist/mermaid.css
@@ -256,5 +256,5 @@ text {
 }
 
 .mermaid {
-  width:1200px;
+  width: auto;
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -109,6 +109,8 @@ cli.prototype.parse = function(argv, next) {
       } catch (err) {
         this.errors.push(err)
       }
+    } else {
+      options.css = fs.readFileSync(__dirname + '/../dist/mermaid.css')
     }
 
     this.checkPhantom = createCheckPhantom(options.phantomPath)

--- a/test/cli_test-parser.js
+++ b/test/cli_test-parser.js
@@ -71,6 +71,17 @@ test('setting an output directory succeeds', function(t) {
   })
 })
 
+test('not setting a css source file uses a default style', function(t) {
+  t.plan(1)
+
+  var cli = require(cliPath)
+
+  cli.parse([], function(err, msg, opt) {
+    t.ok(opt.css, 'css file is populated')
+    t.end()
+  })
+})
+
 test('setting a css source file succeeds', function(t) {
   t.plan(1)
 


### PR DESCRIPTION
Uses the default Mermaid style when no explicit style is set. Fixes #196 

Added a test to prevent regressions and additionally set the width of the default style to "auto".

Honestly I have no idea if setting the width to "auto" would cause any issues, the previous 1200px just generated a weirdly small image on my system.

Before:
![screenshot 2015-09-15 19 26 11](https://cloud.githubusercontent.com/assets/868844/9884371/a8ad6bb2-5bdf-11e5-9d05-89cf7b89f127.png)

After:
![screenshot 2015-09-15 19 26 55](https://cloud.githubusercontent.com/assets/868844/9884399/bf62511a-5bdf-11e5-8071-b8bdcc154e76.png)
