### PR TITLE
flowRender.js - Fix FontAwesome icon insert

### DIFF
--- a/src/diagrams/flowchart/flowRenderer.js
+++ b/src/diagrams/flowchart/flowRenderer.js
@@ -79,7 +79,7 @@ exports.addVertices = function (vert, g) {
         if(conf.htmlLabels) {
             labelTypeStr = 'html';
             verticeText = verticeText.replace(/fa:fa[\w\-]+/g,function(s){
-                return '<i class="fa '+ s.substring(3)+'">';
+                return '<i class="fa '+ s.substring(3)+'"></i>';
             });
 
         } else {


### PR DESCRIPTION
Missing ending tag </i> in FontAwesome icon inserting.