### PR TITLE
gh-50 Allow styling of edge labels in css

### DIFF
--- a/src/diagrams/flowchart/flowRenderer.js
+++ b/src/diagrams/flowchart/flowRenderer.js
@@ -192,7 +192,7 @@ exports.addEdges = function (edges, g) {
             var edgeText = edge.text.replace(/<br>/g, '\n');
             if(typeof edge.style === 'undefined'){
                 if (conf.htmlLabels){
-                    g.setEdge(edge.start, edge.end,{labelType: 'html',style: style, labelpos:'c', label: '<span style="background:#e8e8e8">'+edge.text+'</span>', arrowheadStyle: 'fill: #333', arrowhead: aHead},cnt);
+                    g.setEdge(edge.start, edge.end,{labelType: 'html',style: style, labelpos:'c', label: '<span class="edgeLabel">'+edge.text+'</span>', arrowheadStyle: 'fill: #333', arrowhead: aHead},cnt);
                 }else{
                     g.setEdge(edge.start, edge.end,{labelType: 'text', style: 'stroke: #333; stroke-width: 1.5px;fill:none', labelpos:'c', label: edgeText, arrowheadStyle: 'fill: #333', arrowhead: aHead},cnt);
                 }

--- a/src/less/default/flow.less
+++ b/src/less/default/flow.less
@@ -11,8 +11,12 @@
 
 .edgePath .path {
   stroke: @lineColor;
-  
 }
+
+.edgeLabel {
+  background-color: @edgeLabelBackground;
+}
+
 .cluster rect{
   fill: @secondBkg !important;
   rx:4 !important;

--- a/src/less/default/variables.less
+++ b/src/less/default/variables.less
@@ -15,6 +15,8 @@
 
 @titleColor: #333;
 
+@edgeLabelBackground: #e8e8e8;
+
 /* Sequence Diagram variables */
 @actorBorder: @border1;
 @actorBkg:    @mainBkg;

--- a/src/less/forest/flow.less
+++ b/src/less/forest/flow.less
@@ -15,8 +15,12 @@ color:#333
 .edgePath .path {
   stroke: @lineColor;
   stroke-width: 1.5px;
-  
 }
+
+.edgeLabel {
+  background-color: @edgeLabelBackground;
+}
+
 .cluster rect{
   fill: @secondBkg !important;
   rx:4  !important;

--- a/src/less/forest/variables.less
+++ b/src/less/forest/variables.less
@@ -16,6 +16,8 @@
 
 @titleColor: #333;
 
+@edgeLabelBackground: #e8e8e8;
+
 /* Sequence Diagram variables */
 @actorBorder: @border1;
 @actorBkg:    @mainBkg;


### PR DESCRIPTION
removes the hard-coded background color for edge labels and adds a class 'edgeLabel' to enable styling in css