### PR TITLE
Quote phantomPath so that it doesn't fail on window

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -182,7 +182,7 @@ function createCheckPhantom(_phantomPath) {
     }
 
     // If we have phantompath, see if its version satisfies our requirements
-    exec(phantomPath + ' --version', function(err, stdout, stderr) {
+    exec('"' + phantomPath + '" --version', function(err, stdout, stderr) {
       if (err) {
         next(new Error("Could not find phantomjs at the specified path."))
       }


### PR DESCRIPTION
Quote phantomPath so that it doesn't fail on windows when path has spaces. Fixes #236