### PR TITLE
Issue 299: Sequence diagram Loops: changing boxMargin spoils the "loop" notation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ The following targets are probably interesting:
 
 for instance:
 ```
-gulp jasmine
+gulp jison
 ```
 To run the tests:
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,12 +53,11 @@ Fork, then:
 npm install
 ```
 
-Then the dependencies will have been installed. You use gulp as build tool.
+Then the dependencies will have been installed. You use gulp and npm calls as build tools.
 
 The following targets are probably interesting:
 
 * jison - compiles the jison grammars to parser files
-* dist - complies files to the dist catalog
 
 for instance:
 ```
@@ -67,6 +66,11 @@ gulp jasmine
 To run the tests:
 ```
 npm run karma
+```
+
+To build the /dist directory
+```
+npm run dist
 ```
 
 Thanks, Knut Sveidqvist

--- a/src/diagrams/sequenceDiagram/svgDraw.js
+++ b/src/diagrams/sequenceDiagram/svgDraw.js
@@ -151,8 +151,8 @@ exports.drawLoop = function(elem,bounds,labelText, conf){
     txt.text = labelText;
     txt.x = bounds.startx;
     txt.y = bounds.starty;
-    txt.labelMargin =  1.5 * conf.boxMargin;
-    txt.class =  'labelText';
+    txt.labelMargin =  1.5 * 10; // This is the small box that says "loop"
+    txt.class =  'labelText';    // Its size & position are fixed.
     txt.fill =  'white';
 
     exports.drawLabel(g,txt);


### PR DESCRIPTION
In Sequence diagrams, a loop section draws a box with the word "loop"
in the top left corner. This is all good. In addition, the title of the
loop is in the center of the box, near the top of the box.

To add a bit of margin between the Loop title and the line at the top
of the box, change the configuration field boxMargin

Problem: by error, the boxMargin is also used for positioning the
"loop" label. Since the loop label is in a fixed small place, changing
boxMargin causes the word "loop" to move out of its box.