### PR TITLE
Show a little lenience for white-space around names

### DIFF
--- a/src/diagrams/sequenceDiagram/parser/sequenceDiagram.jison
+++ b/src/diagrams/sequenceDiagram/parser/sequenceDiagram.jison
@@ -44,7 +44,7 @@
 "sequenceDiagram" return 'SD';
 ","               return ',';
 ";"               return 'NL';
-[^\->:\n,;]+      return 'ACTOR';
+[^\->:\n,;]+      { yytext = yytext.trim(); return 'ACTOR'; }
 "->>"             return 'SOLID_ARROW';
 "-->>"            return 'DOTTED_ARROW';
 "->"              return 'SOLID_OPEN_ARROW';


### PR DESCRIPTION
It bugged me this didn't work as an actor would be detected as "B" in one case and "B " in another:

```mermaid
sequenceDiagram
A ->> B: foo
B ->> A: bar
```

A small change to the jison file fixes it.