### PR TITLE
override normal flowchart arrowhead to allow css styling

### DIFF
--- a/src/diagrams/flowchart/flowRenderer.js
+++ b/src/diagrams/flowchart/flowRenderer.js
@@ -425,6 +425,25 @@ exports.draw = function (text, id,isDot) {
         dagreD3.util.applyStyle(path, edge[type + 'Style']);
     };
 
+    // Override normal arrowhead defined in d3. Remove style & add class to allow css styling.
+    render.arrows().normal = function normal(parent, id, edge, type) {
+        var marker = parent.append("marker")
+        .attr("id", id)
+        .attr("viewBox", "0 0 10 10")
+        .attr("refX", 9)
+        .attr("refY", 5)
+        .attr("markerUnits", "strokeWidth")
+        .attr("markerWidth", 8)
+        .attr("markerHeight", 6)
+        .attr("orient", "auto")
+
+        var path = marker.append("path")
+        .attr("d", "M 0 0 L 10 5 L 0 10 z")
+        .attr("class", "arrowheadPath")
+        .style("stroke-width", 1)
+        .style("stroke-dasharray", "1,0");
+    };
+
     // Set up an SVG group so that we can translate the final graph.
     var svg = d3.select('#' + id);
     //svgGroup = d3.select('#' + id + ' g');

--- a/src/less/dark/flow.less
+++ b/src/less/dark/flow.less
@@ -9,6 +9,11 @@
   stroke-width: 1px;
 }
 
+
+.arrowheadPath {
+  fill: @arrowheadColor;
+}
+
 .edgePath .path {
   stroke: @lineColor;
 }

--- a/src/less/dark/variables.less
+++ b/src/less/dark/variables.less
@@ -5,6 +5,7 @@
 @lineColor: @mainContrastColor;
 @border1: #81B1DB;
 @border2: rgba(255, 255, 255, 0.25);
+@arrowheadColor: @mainContrastColor;
 
 
 /* Flowchart variables */

--- a/src/less/default/flow.less
+++ b/src/less/default/flow.less
@@ -9,6 +9,10 @@
   stroke-width: 1px;
 }
 
+.arrowheadPath {
+  fill: @arrowheadColor;
+}
+
 .edgePath .path {
   stroke: @lineColor;
 }

--- a/src/less/default/variables.less
+++ b/src/less/default/variables.less
@@ -3,6 +3,7 @@
 @lineColor: #333333;
 @border1:#CCCCFF;
 @border2:#aaaa33;
+@arrowheadColor: #333333;
 
 /* Flowchart variables */
 @nodeBkg:@mainBkg;

--- a/src/less/forest/flow.less
+++ b/src/less/forest/flow.less
@@ -12,6 +12,10 @@ color:#333
   stroke-width: 1px;
 }
 
+.arrowheadPath {
+  fill: @arrowheadColor;
+}
+
 .edgePath .path {
   stroke: @lineColor;
   stroke-width: 1.5px;

--- a/src/less/forest/variables.less
+++ b/src/less/forest/variables.less
@@ -4,6 +4,7 @@
 @lineColor: green;
 @border1: #13540c;
 @border2: #6eaa49;
+@arrowheadColor: green;
 
 /* Flowchart variables */
 @nodeBkg:@mainBkg;


### PR DESCRIPTION
The arrowhead style in flowchart is hard-coded and cannot be changed. The default color *#333* can be hardly visible against dark backgrounds. See issue #362. 

Since the normal arrowhead used in flowchart is defined in dagre-d3 package and cannot be modified, I overrided it and added a class to the path, and removed the default style.

I also modified the css files so that the default arrowhead color is the same with line color.