### PR TITLE
Add missing space for 'Labels out of bounds' section

### DIFF
--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -77,7 +77,7 @@ Would end up like this:
 ```
 An id is also added to mermaid tags without id.
 
-###Labels out of bounds
+### Labels out of bounds
 
 If you use dynamically loaded fonts that are loaded through CSS, such as Google fonts, mermaid should wait for the 
 whole page to have been loaded (dom + assets, particularly the fonts file).


### PR DESCRIPTION
If you go to http://knsv.github.io/mermaid/#simple-usage-on-a-web-page, you'll see that the '###' did not get translated, probably because there needs to be a space between '###' and the text.