### PR TITLE
#422 use foreignObject/div to place actor label in sequence diagram 

### DIFF
--- a/src/diagrams/sequenceDiagram/sequenceRenderer.js
+++ b/src/diagrams/sequenceDiagram/sequenceRenderer.js
@@ -32,10 +32,12 @@ var conf = {
     bottomMarginAdj:1,
 
     // width of activation box
-    activationWidth:10
+    activationWidth:10,
+
+    //text placement as: tspan | fo
+    textPlacement: 'fo',
 };
 
-//var bb = getBBox('path');
 exports.bounds = {
     data:{
         startx:undefined,
@@ -221,8 +223,8 @@ var drawMessage = function(elem, startx, stopx, verticalPos, msg){
     }
     else{
         //textWidth = getBBox(textElem).width; //.getComputedTextLength()
-        textWidth = textElem[0][0].getBoundingClientRect();  
-        //textWidth = textElem[0][0].getComputedTextLength();  
+        textWidth = textElem[0][0].getBoundingClientRect();
+        //textWidth = textElem[0][0].getComputedTextLength();
     }
 
     var line;
@@ -272,6 +274,7 @@ var drawMessage = function(elem, startx, stopx, verticalPos, msg){
     }
 
 };
+
 
 module.exports.drawActors = function(diagram, actors, actorKeys,verticalPos){
     var i;
@@ -476,14 +479,14 @@ module.exports.draw = function (text, id) {
     }
 
     var width = (box.stopx - box.startx) + (2 * conf.diagramMarginX);
-    
+
     if(title) {
       diagram.append('text')
         .text(title)
         .attr('x', ( ( box.stopx-box.startx) / 2 ) - ( 2 * conf.diagramMarginX ) )
         .attr('y', -25);
     }
-    
+
     if(conf.useMaxWidth) {
         diagram.attr('height', '100%');
         diagram.attr('width', '100%');

--- a/src/diagrams/sequenceDiagram/svgDraw.js
+++ b/src/diagrams/sequenceDiagram/svgDraw.js
@@ -112,17 +112,12 @@ exports.drawActor = function(elem, left, verticalPos, description,conf){
     rect.ry = 3;
     exports.drawRect(g, rect);
 
-    g.append('text')      // text label for the x axis
-        .attr('x', center)
-        .attr('y', verticalPos + (conf.height/2)+5)
-        .attr('class','actor')
-        .style('text-anchor', 'middle')
-        .text(description)
-    ;
+    _drawTextCandidateFunc(conf)(
+      description, g, rect.x, rect.y, rect.width, rect.height);
 };
 
 exports.anchorElement = function(elem) {
-    return elem.append('g');  
+    return elem.append('g');
 };
 /**
  * Draws an actor in the diagram with the attaced line
@@ -269,3 +264,30 @@ exports.getNoteRect = function(){
     };
     return rect;
 };
+
+var _drawTextCandidateFunc = (function() {
+    var byText = function(content, g, x, y, width, height) {
+        var center = x + width / 2;
+        g.append('text')
+          .attr('x', center).attr('y', y + y / 2 + 5)
+          .attr('class', 'actor').style('text-anchor', 'middle')
+          .text(content);
+    };
+    var byFo = function(content, g, x, y, width, height) {
+        var s = g.append('switch');
+        var f = s.append("foreignObject")
+                  .attr('x', x).attr('y', y)
+                  .attr('width', width).attr('height', height);
+
+        f.append('div').style('display', 'table')
+          .style('height', '100%').style('width', '100%')
+          .append('div').style('display', 'table-cell')
+           .style('text-align', 'center').style('vertical-align', 'middle')
+           .text(content)
+
+        byText(content, s, x, y, width, height);
+    };
+    return function(conf) {
+      return conf.textPlacement==='fo' ? byFo : byText;
+    };
+})();

--- a/src/diagrams/sequenceDiagram/svgDraw.js
+++ b/src/diagrams/sequenceDiagram/svgDraw.js
@@ -269,7 +269,7 @@ var _drawTextCandidateFunc = (function() {
     var byText = function(content, g, x, y, width, height) {
         var center = x + width / 2;
         g.append('text')
-          .attr('x', center).attr('y', y + y / 2 + 5)
+          .attr('x', center).attr('y', y + height / 2 + 5)
           .attr('class', 'actor').style('text-anchor', 'middle')
           .text(content);
     };


### PR DESCRIPTION
re #422,  the change to foreignObject/div is enabled by config.textPlacement: fo. Otherwise, use svg text as before without foreignObject.

_drawTextCandidateFunc may be generalized and used elsewhere in sequence diagram and beyond. there is opportunity to consolidate toward to some common code for text placement. 

pased: npm run tape && npm run karma && npm run dist
npm run jasmine was failing unrelated to this change.
manually tested: 
```
   sequenceDiagram
    Alice->>John: Hello John, how are you?
    John-->>Alice: Great!
    very very very long long very long ->> John: ok?
```

the change may go further to consolidate <tspan><br/>\n support. 
please let me know if it's better keep going with in this PR, or new PR after the current changeset is satisfied and merged. 
