### PR TITLE
Allow .node>circle to receive css styles

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -112,7 +112,7 @@ var cloneCssStyles = function(svg, classes){
                 }
             } else {
                 if (classes[className].styles instanceof Array) {
-                    embeddedStyles += '#' + svg.id.trim() + ' .' + className + '>rect, .' + className + '>polygon, .' + className + '>ellipse { ' + classes[className].styles.join('; ') + '; }\n';
+                    embeddedStyles += '#' + svg.id.trim() + ' .' + className + '>rect, .' + className + '>polygon, .' + className + '>circle, .' + className + '>ellipse { ' + classes[className].styles.join('; ') + '; }\n';
                 }
             }
         }

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -196,9 +196,8 @@ describe('when cloning CSS ', function () {
         expect(stylesToArray(svg)).toEqual(['#mermaid-01 .node>rect { stroke:#ffffff; stroke-width:1.5px; }',
             '.node { stroke: #eeeeee;}',
             '.node-square { stroke: #bbbbbb;}',
-            '#mermaid-01 .node-square>rect, .node-square>polygon, .node-square>ellipse { fill:#eeeeee; stroke:#aaaaaa; }',
-            '#mermaid-01 .node-circle>rect, .node-circle>polygon, .node-circle>ellipse { fill:#444444; stroke:#111111; }'
+            '#mermaid-01 .node-square>rect, .node-square>polygon, .node-square>circle, .node-square>ellipse { fill:#eeeeee; stroke:#aaaaaa; }',
+            '#mermaid-01 .node-circle>rect, .node-circle>polygon, .node-circle>circle, .node-circle>ellipse { fill:#444444; stroke:#111111; }'
         ]);
     });
 });
-


### PR DESCRIPTION
Updates the `utils.js` and `utils.spec.js` files to support styles for .node>circle.
Addresses issue https://github.com/knsv/mermaid/issues/443

![screen shot 2017-01-05 at 10 10 26 pm](https://cloud.githubusercontent.com/assets/1695539/21706282/de202f6e-d393-11e6-86b6-206a3beabf34.png)

Using this code in circleColorByClassDef.html
```
    graph LR;
    A((start))-->B(step1);
    B-->C[step2];
    C-->D{step3};
    D-->D2(-step3.5-);
    D2-->E[end];
    classDef yellow fill:#ffff00,stroke:#333,stroke-width:3px;
    class A,B,C,D,D2,E yellow;
```