### PR TITLE
Add viewbox attr to class diagram

### DIFF
--- a/src/diagrams/classDiagram/classRenderer.js
+++ b/src/diagrams/classDiagram/classRenderer.js
@@ -405,6 +405,7 @@ module.exports.draw = function (text, id) {
     //
     diagram.attr('height', '100%');
     diagram.attr('width', '100%');
+    diagram.attr('viewBox', '0 0 ' + (g.graph().width + 20) + ' ' + (g.graph().height + 20));
     //
     //
     //


### PR DESCRIPTION
Add viewbox attr to class diagram for being able to display whole diagram.
Before adding this codes, it displays a part of diagram as the following image.
![2017-02-07_18h36_37](https://cloud.githubusercontent.com/assets/2316494/22685900/72e03118-ed65-11e6-880a-fae461c43993.png)

