### PR TITLE
Fix links in documentations

### DIFF
--- a/docs/content/gantt.md
+++ b/docs/content/gantt.md
@@ -45,7 +45,7 @@ gantt
         Completed task            :done,    des1, 2014-01-06,2014-01-08
         Active task               :active,  des2, 2014-01-09, 3d
         Future task               :         des3, after des2, 5d
-        Future task2               :         des4, after des3, 5d
+        Future task2              :         des4, after des3, 5d
 
         section Critical tasks
         Completed task in the critical line :crit, done, 2014-01-06,24h
@@ -62,8 +62,8 @@ gantt
         
         section Last section
         Describe gantt syntax               :after doc1, 3d
-        Add gantt diagram to demo page      : 20h
-        Add another diagram to demo page    : 48h
+        Add gantt diagram to demo page      :20h
+        Add another diagram to demo page    :48h
 ``` 
 
 Renders like below:
@@ -77,7 +77,7 @@ gantt
        Completed task            :done,    des1, 2014-01-06,2014-01-08
        Active task               :active,  des2, 2014-01-09, 3d
        Future task               :         des3, after des2, 5d
-       Future task2               :         des4, after des3, 5d
+       Future task2              :         des4, after des3, 5d
 
        section Critical tasks
        Completed task in the critical line :crit, done, 2014-01-06,24h
@@ -94,10 +94,10 @@ gantt
        
        section Last section
        Describe gantt syntax               :after doc1, 3d
-       Add gantt diagram to demo page      : 20h
-       Add another diagram to demo page    : 48h
-   ```  
-### title
+       Add gantt diagram to demo page      :20h
+       Add another diagram to demo page    :48h
+```  
+### Title
 
 Tbd
 
@@ -108,7 +108,6 @@ Tbd
 ## Setting dates
 
 Tbd
-
 
 ### Date format
 
@@ -251,5 +250,5 @@ noteText     | Styles for the text on in the note boxes.
 
 Is it possible to adjust the margins for rendering the sequence diagram.
 
-This is done by defining the **sequenceConfig** part of the configuration object. Read more about it [here](http://knsv.github.io/mermaid/index.html#configuration28). How to use
-the CLI is described in the [mermaidCLI]((http://knsv.github.io/mermaid/index.html#mermaidCLI) page.
+This is done by defining the **sequenceConfig** part of the configuration object. Read more about it [here](#configuration35).
+How to use the CLI is described in the [mermaidCLI](#mermaid-cli8) page.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -4,15 +4,13 @@ order: 0
 
 mermaid
 =======
-![Alt text](images/header.png)
+![Header Image](images/header.png)
 
 >Generation of diagrams and flowcharts from text in a similar manner as markdown.
 
 Ever wanted to simplify documentation and avoid heavy tools like Visio when explaining your code?
 
-
-This is why mermaid was born, a simple markdown-like script language for generating charts from text via javascript. [Try it using our editor](http://knsv.github.io/mermaid/live_editor).
-
+This is why mermaid was born, a simple markdown-like script language for generating charts from text via javascript. [Try it using our editor][live_editor].
 
 Code examples below:
 
@@ -59,13 +57,11 @@ gantt
         Add to mermaid                      :1d
 ```
 
-Play with mermaid using this [editor](http://danielmschmidt.github.io/mermaid-demo/) or this [live editor](live_editor).
+Play with mermaid using this [editor](https://danielmschmidt.github.io/mermaid-demo/) or this [live editor][live_editor].
 
 ## Credits
-Many thanks to the [d3](http://d3js.org/) and [dagre-d3](https://github.com/cpettitt/dagre-d3) projects for providing
-the graphical layout and drawing libraries! Thanks also to the
-[js-sequence-diagram](http://bramp.github.io/js-sequence-diagrams) project for usage of the grammar for the
-sequence diagrams.
+Many thanks to the [d3](https://d3js.org/) and [dagre-d3](https://github.com/cpettitt/dagre-d3) projects for providing the graphical layout and drawing libraries!
+Thanks also to the [js-sequence-diagram](https://bramp.github.io/js-sequence-diagrams) project for usage of the grammar for the sequence diagrams.
 
 *Mermaid was created by Knut Sveidqvist for easier documentation.*
 
@@ -84,7 +80,7 @@ Mermaid is supported in a number of publishing systems and editors. Please repor
 * [Using mermaid via Octopress](http://mostlyblather.com/blog/2015/05/23/mermaid-jekyll-octopress/)
 * [Mardown editor Haroopad](http://pad.haroopress.com/user.html)
 * [Plugin for atom](https://atom.io/packages/atom-mermaid)
-* [Markdown Plus](http://mdp.tylingsoft.com/)
+* [Markdown Plus](https://mdp.tylingsoft.com/)
 * [Vim Plugin](https://github.com/kannokanno/previm)
 * [Sphinx extension](https://github.com/mgaitan/sphinxcontrib-mermaid)
 * [Pandoc filter](https://github.com/raghur/mermaid-filter)
@@ -98,4 +94,6 @@ An editor is available for creating diagrams. With it you can quickly start writ
 * get a link to a viewer of the diagram
 * get a link to edit of the diagram to share a diagram so that someone else can tweak it and send a new link back
 
-* [Editor](http://knsv.github.io/mermaid/live_editor)
+* [Editor][live_editor]
+
+[live_editor]: https://knsv.github.io/mermaid/live_editor/

--- a/docs/content/sequenceDiagram.md
+++ b/docs/content/sequenceDiagram.md
@@ -59,17 +59,14 @@ Messages can be of two displayed either solid or with a dotted line.
 
 There are six types of arrows currently supported:
 
--> which will render a solid line without arrow
-
---> which will render a dotted line  without arrow
-
-->> which will render a solid line with arrowhead
-
--->> which will render a dotted line  with arrowhead
-
--x which will render a solid line with a cross at the end (async)
-
---x which will render a dotted line with a cross at the end (async)
+Type | Description
+---  | ---
+->   | Solid line without arrow
+-->  | Dotted line  without arrow
+->>  | Solid line with arrowhead
+-->> | Dotted line  with arrowhead
+-x   | Solid line with a cross at the end (async)
+--x  | Dotted line with a cross at the end (async)
 
 
 ## Activations
@@ -337,9 +334,9 @@ text.actor {
 
 Is it possible to adjust the margins for rendering the sequence diagram.
 
-This is done by defining **mermaid.sequenceConfig** or by the CLI to use a json file with the configuration. How to use
-the CLI is described in the mermaidCLI page.
-mermaid.sequenceConfig can be set to a JSON string with config parameters or the corresponding object.
+This is done by defining **mermaid.sequenceConfig** or by the CLI to use a json file with the configuration.
+How to use the CLI is described in the [mermaidCLI](#mermaid-cli8) page.
+**mermaid.sequenceConfig** can be set to a JSON string with config parameters or the corresponding object.
 
 ```
 mermaid.sequenceConfig = {
@@ -356,5 +353,5 @@ mermaid.sequenceConfig = {
 
 Param | Descriotion | Default value
 --- | --- | ---
-mirrorActor|Turns on/off the rendering of actors below the diagram as well as above it|false
-bottomMarginAdj|Adjusts how far down the graph ended. Wide borders styles with css could generate unwantewd clipping which is why this config param exists.|1
+mirrorActor     | Turns on/off the rendering of actors below the diagram as well as above it                                                                  | false
+bottomMarginAdj | Adjusts how far down the graph ended. Wide borders styles with css could generate unwantewd clipping which is why this config param exists. | 1


### PR DESCRIPTION
* The main change (in term of importance) is the fix of two broken links that were
pointing to outdated sections ids.
* Added a link to mermaidCLI in the sequenceDiagram section, to reflect the one in
the gantt section.

* Converted some links to https.


I also isolated that the "Simple full example" section in `usage.md` is the one that is breaking the site (#484), however I don't really know how to fix it and I'm not in capacity of generating the documentation locally (don't really know how) to check and debug it, so I'm leaving it to you.