### PR TITLE
Dont continue when a parse error has occurred

### DIFF
--- a/src/diagrams/flowchart/parser/flow.js
+++ b/src/diagrams/flowchart/parser/flow.js
@@ -386,6 +386,7 @@ var parser = (function () {
             loc: yyloc,
             expected: expected
           })
+          return false
         }
         if (action[0] instanceof Array && action.length > 1) {
           throw new Error('Parse Error: multiple actions possible at state: ' + state + ', token: ' + symbol)


### PR DESCRIPTION
Else the code will throw an error when it tries to access `action[0]`