### PR TITLE
Spec fix 1

### DIFF
--- a/src/diagrams/gantt/gantt.spec.js
+++ b/src/diagrams/gantt/gantt.spec.js
@@ -7,22 +7,22 @@ describe('when parsing a gantt diagram it', function () {
     parser.yy = ganttDb
   })
 
-  it('should handle an dateFormat definition', function () {
+  it('should handle a dateFormat definition', function () {
     const str = 'gantt\ndateFormat yyyy-mm-dd'
 
     parser.parse(str)
   })
-  it('should handle an dateFormat definition', function () {
+  it('should handle a dateFormat definition', function () {
     const str = 'gantt\ndateFormat yyyy-mm-dd\ntitle Adding gantt diagram functionality to mermaid'
 
     parser.parse(str)
   })
-  it('should handle an dateFormat definition', function () {
+  it('should handle a dateFormat definition', function () {
     const str = 'gantt\ndateFormat yyyy-mm-dd\ntitle Adding gantt diagram functionality to mermaid'
 
     parser.parse(str)
   })
-  it('should handle an section definition', function () {
+  it('should handle a section definition', function () {
     const str = 'gantt\ndateFormat yyyy-mm-dd\ntitle Adding gantt diagram functionality to mermaid'
 
     parser.parse(str)

--- a/src/diagrams/gantt/gantt.spec.js
+++ b/src/diagrams/gantt/gantt.spec.js
@@ -12,18 +12,16 @@ describe('when parsing a gantt diagram it', function () {
 
     parser.parse(str)
   })
-  it('should handle a dateFormat definition', function () {
-    const str = 'gantt\ndateFormat yyyy-mm-dd\ntitle Adding gantt diagram functionality to mermaid'
-
-    parser.parse(str)
-  })
-  it('should handle a dateFormat definition', function () {
+  it('should handle a title definition', function () {
     const str = 'gantt\ndateFormat yyyy-mm-dd\ntitle Adding gantt diagram functionality to mermaid'
 
     parser.parse(str)
   })
   it('should handle a section definition', function () {
-    const str = 'gantt\ndateFormat yyyy-mm-dd\ntitle Adding gantt diagram functionality to mermaid'
+    const str = 'gantt\n' +
+      'dateFormat yyyy-mm-dd\n' +
+      'title Adding gantt diagram functionality to mermaid\n' +
+      'section Documentation'
 
     parser.parse(str)
   })


### PR DESCRIPTION
This PR fixes several small problems in the Gantt spec:
- fixes grammar in the specs ("a" instead of "an")
- removes duplicate test for date spec
- fixes naming of title spec
- adds an actual section to the section spec input to ensure the test does what it says :-)