### PR TITLE
feat(Arrows): enable custom styling of dotted arrows

### DIFF
--- a/src/diagrams/flowchart/flowRenderer.js
+++ b/src/diagrams/flowchart/flowRenderer.js
@@ -163,7 +163,12 @@ export const addEdges = function (edges, g) {
           }
           break
         case 'dotted':
-          style = 'stroke: #333; fill:none;stroke-width:2px;stroke-dasharray:3;'
+          style = 'stroke-dasharray:3;'
+          if (typeof defaultStyle !== 'undefined') {
+            style += defaultStyle
+          } else {
+            style += 'stroke: #333; fill:none;stroke-width:2px;'
+          }
           break
         case 'thick':
           style = 'stroke: #333; stroke-width: 3.5px;fill:none'


### PR DESCRIPTION
Hi,

I am working with Mermaid and realised dotted arrows in flowcharts cannot be styled, ending up in a difference of style between regular ones and dotted ones.

I didn't want to change thoroughly the style of the code around, so that's I am using this approach.

Please let me know if you want any changes.

Cheers and thanks for the good library