### PR TITLE
Allow for rect dropshadows, styleable note text, and rounded corners

### DIFF
--- a/src/diagrams/sequence/sequenceRenderer.js
+++ b/src/diagrams/sequence/sequenceRenderer.js
@@ -174,7 +174,7 @@ const _drawLongText = (text, x, y, g, width) => {
 /**
  * Draws an actor in the diagram with the attaced line
  * @param center - The center of the the actor
- * @param pos The position if the actor in the liost of actors
+ * @param pos The position if the actor in the list of actors
  * @param description The text in the box
  */
 const drawNote = function (elem, startx, verticalPos, msg, forceWidth) {
@@ -185,7 +185,7 @@ const drawNote = function (elem, startx, verticalPos, msg, forceWidth) {
   rect.class = 'note'
 
   let g = elem.append('g')
-  const rectElem = svgDraw.drawRect(g, rect)
+  const rectElem = svgDraw.drawRect(g, rect, conf)
 
   const textHeight = _drawLongText(msg.message, startx - 4, verticalPos + 24, g, rect.width - conf.noteMargin)
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -64,3 +64,10 @@ export default {
   isSubstringInArray,
   interpolateToCurve
 }
+
+export const generateId = (prefix) => {
+  const S4 = function () {
+    return (((1 + Math.random()) * 0x10000) | 0).toString(16).substring(1)
+  }
+  return `${prefix}${(S4() + S4() + '-' + S4() + '-' + S4() + '-' + S4() + '-' + S4() + S4() + S4())}`
+}


### PR DESCRIPTION
I'd like to make my sequence diagrams prettier so I found a couple configurations to `rects` that needed to be tweaked. I've introduced a `rect` configuration variable that can be used to override `rect` attributes as well as offer specialized options such as `rect.dropShadow`.

For example to add a drop shadow to the rects in a sequence diagram you do:

```js
mermaid.initialize({
        logLevel: 3,
        startOnLoad: true,
        cloneCssStyles: false,
        sequence: {
            actorMargin: 50,
            mirrorActors: false,
            borderRadius: 5,
            rect: {
                dropShadow: true
            }
        },
        themeCSS: "<%= diagram_css %>"
    });
```

If you want to tweak the round-ness of the corners of rectangles you can do:

```js
mermaid.initialize({
        logLevel: 3,
        startOnLoad: true,
        cloneCssStyles: false,
        sequence: {
            actorMargin: 50,
            mirrorActors: false,
            borderRadius: 5,
            rect: {
                attrs: {
                  rx: '3',
                  ry: '3'
                }
            }
        },
        themeCSS: "<%= diagram_css %>"
    });
```

In addition I found that `svgDraw.getTextObj` forces a `black` `fill`, rather than letting the CSS apply styles to this. This could be a breaking change however to existing users.

I'm curious what the maintainers think about these changes and if there any chances I get this potentially merged upstream.