### PR TITLE
Add nested activation classes

### DIFF
--- a/src/diagrams/sequence/sequenceRenderer.js
+++ b/src/diagrams/sequence/sequenceRenderer.js
@@ -338,7 +338,7 @@ export const draw = function (text, id) {
       activationData.starty = verticalPos - 6
       verticalPos += 12
     }
-    svgDraw.drawActivation(diagram, activationData, verticalPos, conf)
+    svgDraw.drawActivation(diagram, activationData, verticalPos, conf, actorActivations(msg.from.actor).length)
 
     bounds.insert(activationData.startx, verticalPos - 10, activationData.stopx, verticalPos)
   }

--- a/src/diagrams/sequence/svgDraw.js
+++ b/src/diagrams/sequence/svgDraw.js
@@ -106,7 +106,7 @@ export const drawActivation = function (elem, bounds, verticalPos) {
   const g = bounds.anchored
   rect.x = bounds.startx
   rect.y = bounds.starty
-  rect.fill = '#f4f4f4'
+  rect.class = 'activation'
   rect.width = bounds.stopx - bounds.startx
   rect.height = verticalPos - bounds.starty
   drawRect(g, rect)

--- a/src/diagrams/sequence/svgDraw.js
+++ b/src/diagrams/sequence/svgDraw.js
@@ -106,7 +106,7 @@ export const drawActivation = function (elem, bounds, verticalPos, conf, actorAc
   const g = bounds.anchored
   rect.x = bounds.startx
   rect.y = bounds.starty
-  rect.class = 'activation' + actorActivations
+  rect.class = 'activation' + (actorActivations % 3) // Will evaluate to 0, 1 or 2
   rect.width = bounds.stopx - bounds.startx
   rect.height = verticalPos - bounds.starty
   drawRect(g, rect)

--- a/src/diagrams/sequence/svgDraw.js
+++ b/src/diagrams/sequence/svgDraw.js
@@ -101,12 +101,12 @@ export const anchorElement = function (elem) {
  * @param bounds - activation box bounds
  * @param verticalPos - precise y cooridnate of bottom activation box edge
  */
-export const drawActivation = function (elem, bounds, verticalPos) {
+export const drawActivation = function (elem, bounds, verticalPos, conf, actorActivations) {
   const rect = getNoteRect()
   const g = bounds.anchored
   rect.x = bounds.startx
   rect.y = bounds.starty
-  rect.class = 'activation'
+  rect.class = 'activation' + actorActivations
   rect.width = bounds.stopx - bounds.startx
   rect.height = verticalPos - bounds.starty
   drawRect(g, rect)

--- a/src/themes/dark/index.scss
+++ b/src/themes/dark/index.scss
@@ -30,6 +30,8 @@ $labelBoxBorderColor: $actorBorder;
 $labelTextColor: $mainContrastColor;
 $noteBorderColor: $border2;
 $noteBkgColor: #fff5ad;
+$activationBorderColor: #666;
+$activationBkgColor: #f4f4f4;
 
 /* Gantt chart variables */
 

--- a/src/themes/default/index.scss
+++ b/src/themes/default/index.scss
@@ -28,6 +28,8 @@ $labelBoxBorderColor: $actorBorder;
 $labelTextColor: $actorTextColor;
 $noteBorderColor: $border2;
 $noteBkgColor: #fff5ad;
+$activationBorderColor: #666;
+$activationBkgColor: #f4f4f4;
 
 /* Gantt chart variables */
 

--- a/src/themes/forest/index.scss
+++ b/src/themes/forest/index.scss
@@ -29,6 +29,8 @@ $labelBoxBorderColor: #326932;
 $labelTextColor: $actorTextColor;
 $noteBorderColor: $border2;
 $noteBkgColor: #fff5ad;
+$activationBorderColor: #666;
+$activationBkgColor: #f4f4f4;
 
 /* Gantt chart variables */
 

--- a/src/themes/neutral/index.scss
+++ b/src/themes/neutral/index.scss
@@ -33,6 +33,8 @@ $labelBoxBorderColor: $actorBorder;
 $labelTextColor: white;
 $noteBorderColor: darken($note, 60%);
 $noteBkgColor: $note;
+$activationBorderColor: #666;
+$activationBkgColor: #f4f4f4;
 
 /* Gantt chart variables */
 

--- a/src/themes/sequence.scss
+++ b/src/themes/sequence.scss
@@ -73,3 +73,8 @@ text.actor {
   font-family: 'trebuchet ms', verdana, arial;
   font-size: 14px;
 }
+
+.activation {
+  fill: $activationBkgColor;
+  stroke: $activationBorderColor;
+}

--- a/src/themes/sequence.scss
+++ b/src/themes/sequence.scss
@@ -74,7 +74,17 @@ text.actor {
   font-size: 14px;
 }
 
-.activation {
+.activation0 {
+  fill: $activationBkgColor;
+  stroke: $activationBorderColor;
+}
+
+.activation1 { 
+  fill: $activationBkgColor;
+  stroke: $activationBorderColor;
+}
+
+.activation2 {
   fill: $activationBkgColor;
   stroke: $activationBorderColor;
 }


### PR DESCRIPTION
This branch removes hard-coded styles for activation, and moves them to css theme files so user can edit styles. It also creates separate styles for nested activations (three levels deep)