### PR TITLE
Fix issue with marker-end.

### DIFF
--- a/src/themes/sequence.scss
+++ b/src/themes/sequence.scss
@@ -15,7 +15,7 @@ text.actor {
 .messageLine0 {
   stroke-width: 1.5;
   stroke-dasharray: '2 2';
-  marker-end: 'url(#arrowhead)';
+  marker-end: url(#arrowhead);
   stroke: $signalColor;
 }
 
@@ -57,7 +57,7 @@ text.actor {
 .loopLine {
   stroke-width: 2;
   stroke-dasharray: '2 2';
-  marker-end: 'url(#arrowhead)';
+  marker-end: url(#arrowhead);
   stroke: $labelBoxBorderColor;
 }
 


### PR DESCRIPTION
I had issues with marker-end. Assuming that CSS got more strict over time.

Used mermaid inside docsify and had to fix the Css globaly:
``` css
<style>
  .messageLine0
  {
	marker-end: url(#arrowhead) !important;
	
  }
  .messageLine1
  {
	marker-end: url(#arrowhead) !important;
  }
  
  </style>
```