### PR TITLE
Remove duplicate code

### DIFF
--- a/src/diagrams/flowchart/flowDb.js
+++ b/src/diagrams/flowchart/flowDb.js
@@ -45,9 +45,6 @@ export const addVertex = function (id, text, type, style) {
   if (typeof type !== 'undefined') {
     vertices[id].type = type
   }
-  if (typeof type !== 'undefined') {
-    vertices[id].type = type
-  }
   if (typeof style !== 'undefined') {
     if (style !== null) {
       style.forEach(function (s) {


### PR DESCRIPTION
The deleted code is the logic to check if the type is not 'undefined' and assign it to the vertex if it's not undefined.

However, this code does not seem essential because same code exists just above it.