### PR TITLE
SVG link rendering

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,0 @@
-{
-  "presets": [
-    "@babel/preset-env"
-  ]
-}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  'presets': [
+    '@babel/preset-env'
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -75,6 +75,12 @@
     "src"
   ],
   "jest": {
+    "transform": {
+      "^.+\\.jsx?$": "./transformer.js"
+    },
+    "transformIgnorePatterns": [
+      "/node_modules/(?!dagre-d3-renderer/lib).*\\.js"
+    ],
     "moduleNameMapper": {
       "\\.(css|scss)$": "identity-obj-proxy"
     }

--- a/src/diagrams/flowchart/flowRenderer.js
+++ b/src/diagrams/flowchart/flowRenderer.js
@@ -67,6 +67,7 @@ export const addVertices = function (vert, g, svgId) {
       // TODO: addHtmlLabel accepts a labelStyle. Do we possibly have that?
       const node = { label: vertexText.replace(/fa[lrsb]?:fa-[\w-]+/g, s => `<i class='${s.replace(':', ' ')}'></i>`) }
       vertexNode = addHtmlLabel(svg, node).node()
+      vertexNode.parentNode.removeChild(vertexNode)
     } else {
       const svgLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text')
 
@@ -120,8 +121,6 @@ export const addVertices = function (vert, g, svgId) {
         break
       case 'group':
         _shape = 'rect'
-        // Since we use svg labels, we need to create a text node, see #367
-        vertexNode = document.createElementNS('http://www.w3.org/2000/svg', 'text')
         break
       default:
         _shape = 'rect'
@@ -420,6 +419,7 @@ export const draw = function (text, id) {
   // Index nodes
   flowDb.indexNodes('subGraph' + i)
 
+  // reposition labels
   for (i = 0; i < subGraphs.length; i++) {
     subG = subGraphs[i]
 
@@ -431,19 +431,9 @@ export const draw = function (text, id) {
       const yPos = clusterRects[0].y.baseVal.value
       const width = clusterRects[0].width.baseVal.value
       const cluster = d3.select(clusterEl[0])
-      const te = cluster.append('text')
-      te.attr('x', xPos + width / 2)
-      te.attr('y', yPos + 14)
-      te.attr('fill', 'black')
-      te.attr('stroke', 'none')
+      const te = cluster.select('.label')
+      te.attr('transform', `translate(${xPos + width / 2}, ${yPos + 14})`)
       te.attr('id', id + 'Text')
-      te.style('text-anchor', 'middle')
-
-      if (typeof subG.title === 'undefined') {
-        te.text('Undef')
-      } else {
-        te.text(subG.title)
-      }
     }
   }
 

--- a/src/mermaidAPI.js
+++ b/src/mermaidAPI.js
@@ -50,7 +50,7 @@ for (const themeName of ['default', 'forest', 'dark', 'neutral']) {
  */
 const config = {
 
-/** theme , the CSS style sheet
+  /** theme , the CSS style sheet
   *
   * **theme** - Choose one of the built-in themes: default, forest, dark or neutral. To disable any pre-defined mermaid theme, use "null".
   * **themeCSS** - Use your own CSS. This overrides **theme**.

--- a/transformer.js
+++ b/transformer.js
@@ -1,0 +1,3 @@
+module.exports = require('babel-jest').createTransformer({
+  rootMode: 'upward'
+})

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -8,7 +8,10 @@ const amdRule = {
 
 const jsRule = {
   test: /\.js$/,
-  exclude: /node_modules/,
+  include: [
+    path.resolve(__dirname, './src'),
+    path.resolve(__dirname, './node_modules/dagre-d3-renderer/lib')
+  ],
   use: {
     loader: 'babel-loader'
   }


### PR DESCRIPTION
This continues #765. Currently, links don’t cover the full node area, just a line within the foreignObject. This PR changes that.

## Design

I don’t pass `labelType` to the renderer anymore, but construct SVG in all cases. I use `addHtmlLabel` from `dagre-d3-renderer` instead of duplicating its code for this.

That’s necessary because `dagre-d3-renderer` doesn’t offer a hook to postprocess rendered SVG nodes – if it did, we could simply use that hook to wrap the SVG group in an SVG link.

## TODOs

- [ ] Unfortunately this needs to render the vertices in a live SVG instead of delaying that to the renderer: I had to add a parameter to `addVertices` to achieve that, I hope that’s acceptable. The reason is that in `addHtmlLabel`, the renderer needs to retrieve the bounding box of the foreignObject contents in order to set the node size. Without a live SVG there’s no bounding box, so if we want to call `addHtmlLabel` ourselves instead of letting the renderer do it, we need the live SVG.
- [ ] I’m not sure if we do `labelType: text`, but if we do, I need to adapt this PR for it (currently it’s not handled I think)
- [ ] Finally, the sizes aren’t perfectly determined for clickable non-link nodes. I don’t know what causes that, maybe someone can help:

    Before | This PR
    --- | ---
    ![Before](https://user-images.githubusercontent.com/291575/52334711-a3eb8a80-2a00-11e9-9c7a-8f09b9a6f763.png) | ![After](https://user-images.githubusercontent.com/291575/52334690-933b1480-2a00-11e9-8b76-863048148050.png)

    (note the g in „Shopping“)

## Alternatives

1. We do some postprocessing, so instead of this, we could save the link into a node’s `data-link` attribute and wrap the nodes in a postprocessing step here

    https://github.com/knsv/mermaid/blob/12b58a17e10988b1cc7790f721e4e59fc6150d52/src/diagrams/flowchart/flowRenderer.js#L405-L410

    That would be easier but less elegant and less performant. (we’d have to touch each label, replace it with a link node, and insert it below that link node again. Many many DOM manipulations)

2. We could enhance `dagre-d3-renderer` with first-class link support or a postprocessing hook. The hook has the same problem as alternative 1 and it’s unclear if enhancing it by a link property has a place in the current dagre node model. Would need some investigation.

## Tests

By introducing ES6 imports from `node_modules`, I had to change the way the babel config is loaded (see d78b33ca759f329093a232c39345ce46a273d373). What I did is described [here](https://babeljs.io/docs/en/config-files#6x-vs-7x-babelrc-loading).