### PR TITLE
Added exclude weekdays to definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 **Merged pull requests:**
 
+- Adding weekend ignore do Gantt [\$314] (https://github.com/knsv/mermaid/issues/314)
+
 - Adding init argument to the global API [\#137](https://github.com/knsv/mermaid/pull/137) ([bollwyvl](https://github.com/bollwyvl))
 
 - Add description of manual calling of init [\#136](https://github.com/knsv/mermaid/pull/136) ([bollwyvl](https://github.com/bollwyvl))

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ sequenceDiagram
 gantt
 dateFormat  YYYY-MM-DD
 title Adding GANTT diagram to mermaid
+excludes weekdays 2014-01-10
 
 section A section
 Completed task            :done,    des1, 2014-01-06,2014-01-08

--- a/dist/index.html
+++ b/dist/index.html
@@ -268,6 +268,7 @@ gantt
 dateFormat  YYYY-MM-DD
 axisFormat  %d/%m
 title Adding GANTT diagram to mermaid
+excludes weekdays 2014-01-10
 
 section A section
 Completed task            :done,    des1, 2014-01-06,2014-01-08

--- a/src/diagrams/gantt/gantt.spec.js
+++ b/src/diagrams/gantt/gantt.spec.js
@@ -17,10 +17,16 @@ describe('when parsing a gantt diagram it', function () {
 
     parser.parse(str)
   })
+  it('should handle an excludes definition', function () {
+    const str = 'gantt\ndateFormat yyyy-mm-dd\ntitle Adding gantt diagram functionality to mermaid\nexcludes weekdays 2019-02-01'
+
+    parser.parse(str)
+  })
   it('should handle a section definition', function () {
     const str = 'gantt\n' +
       'dateFormat yyyy-mm-dd\n' +
       'title Adding gantt diagram functionality to mermaid\n' +
+      'excludes weekdays 2019-02-01\n' +
       'section Documentation'
 
     parser.parse(str)

--- a/src/diagrams/gantt/ganttDb.js
+++ b/src/diagrams/gantt/ganttDb.js
@@ -63,19 +63,17 @@ export const getTasks = function () {
   return tasks
 }
 
+const isInvalidDate = function (date, dateFormat, excludes) {
+  if (date.isoWeekday() >= 6 && excludes.indexOf('weekends') >= 0)
+    return true;
+  return excludes.indexOf(date.format(dateFormat.trim())) >= 0;
+}
+
 const getNextValidDate = function (date, dateFormat, excludes) {
-  const excludeWeekends = excludes.indexOf('weekend') >= 0 || excludes.indexOf('weekends') >= 0
-  const trimmedDateFormat = dateFormat.trim()
-  let mDate = moment.isMoment(date) ? date : (moment.isDate(date) ? moment(date) : moment(date, dateFormat, true))
-
-  const isInvalidDate = function (d) {
-    return (excludeWeekends && d.isoWeekday() >= 6) || (excludes.indexOf(d.format(trimmedDateFormat)) >= 0)
-  }
-
-  while (isInvalidDate(mDate)) {
+  let mDate = moment(date, dateFormat, true)
+  while (isInvalidDate(mDate, dateFormat, excludes)) {
     mDate = mDate.add(1, 'd')
   }
-
   return mDate.toDate()
 }
 

--- a/src/diagrams/gantt/ganttDb.js
+++ b/src/diagrams/gantt/ganttDb.js
@@ -74,7 +74,7 @@ const isInvalidDate = function (date, dateFormat, excludes) {
 }
 
 const fixTaskDates = function (task, dateFormat, excludes) {
-  if (excludes.length && ! task.manualEndTime) {
+  if (excludes.length && !task.manualEndTime) {
     let startTime = moment(task.startTime).add(1, 'd')
     let endTime = moment(task.endTime)
     while (startTime.date() <= endTime.date()) {
@@ -233,7 +233,7 @@ const compileData = function (prevTask, dataStr) {
 
   if (endTimeData) {
     task.endTime = getEndDate(task.startTime, dateFormat, endTimeData)
-    task.manualEndTime = endTimeData == moment(task.endTime).format(dateFormat.trim())
+    task.manualEndTime = endTimeData === moment(task.endTime).format(dateFormat.trim())
     fixTaskDates(task, dateFormat, excludes)
   }
 
@@ -371,8 +371,8 @@ const compileTasks = function () {
       rawTasks[pos].endTime = getEndDate(rawTasks[pos].startTime, dateFormat, rawTasks[pos].raw.endTime.data)
       if (rawTasks[pos].endTime) {
         rawTasks[pos].processed = true
-        rawTasks[pos].manualEndTime = rawTasks[pos].raw.endTime.data == moment(rawTasks[pos].endTime).format(dateFormat.trim());
-        fixTaskDates(rawTasks[pos], dateFormat, excludes);
+        rawTasks[pos].manualEndTime = rawTasks[pos].raw.endTime.data === moment(rawTasks[pos].endTime).format(dateFormat.trim())
+        fixTaskDates(rawTasks[pos], dateFormat, excludes)
       }
     }
 

--- a/src/diagrams/gantt/ganttDb.js
+++ b/src/diagrams/gantt/ganttDb.js
@@ -74,19 +74,16 @@ const isInvalidDate = function (date, dateFormat, excludes) {
 }
 
 const fixTaskDates = function (task, dateFormat, excludes) {
-  if (! excludes.length || task.manualEndTime) return;
-
+  if (!excludes.length || task.manualEndTime) return
   let startTime = moment(task.startTime)
   startTime.add(1, 'd')
   let endTime = moment(task.endTime)
-
   while (startTime.date() <= endTime.date()) {
     if (isInvalidDate(startTime, dateFormat, excludes)) {
       endTime.add(1, 'd')
     }
     startTime.add(1, 'd')
   }
-  
   task.endTime = endTime.toDate()
 }
 

--- a/src/diagrams/gantt/ganttDb.js
+++ b/src/diagrams/gantt/ganttDb.js
@@ -92,10 +92,8 @@ const getStartDate = function (prevTime, dateFormat, excludes, str) {
     if (typeof task === 'undefined') {
       const dt = new Date()
       dt.setHours(0, 0, 0, 0)
-      // return getNextValidDate(dt, dateFormat, excludes)
       return dt
     }
-    // return getNextValidDate(task.endTime, dateFormat, excludes)
     return task.endTime
   }
 
@@ -118,7 +116,6 @@ const getEndDate = function (prevTime, dateFormat, excludes, str) {
   // Check for actual date
   let mDate = moment(str, dateFormat.trim(), true)
   if (mDate.isValid()) {
-    // return getNextValidDate(mDate, dateFormat, excludes)
     return mDate.toDate()
   }
 

--- a/src/diagrams/gantt/ganttDb.js
+++ b/src/diagrams/gantt/ganttDb.js
@@ -75,17 +75,20 @@ const isInvalidDate = function (date, dateFormat, excludes) {
 
 const checkTaskDates = function (task, dateFormat, excludes) {
   if (!excludes.length || task.manualEndTime) return
-  fixTaskDates(task, dateFormat, excludes)
+  let startTime = moment(task.startTime, dateFormat, true)
+  startTime.add(1, 'd')
+  let endTime = moment(task.endTime, dateFormat, true)
+  let renderEndTime = fixTaskDates(startTime, endTime, dateFormat, excludes)
+  task.endTime = endTime.toDate()
+  task.renderEndTime = renderEndTime
 }
 
-const fixTaskDates = function (task, dateFormat, excludes) {
-  let startTime = moment(task.startTime)
-  startTime.add(1, 'd')
-  let endTime = moment(task.endTime)
+const fixTaskDates = function (startTime, endTime, dateFormat, excludes) {
   let invalid = false
+  let renderEndTime = null
   while (startTime.date() <= endTime.date()) {
     if (!invalid) {
-      task.renderEndTime = endTime.toDate()
+      renderEndTime = endTime.toDate()
     }
     invalid = isInvalidDate(startTime, dateFormat, excludes)
     if (invalid) {
@@ -93,7 +96,7 @@ const fixTaskDates = function (task, dateFormat, excludes) {
     }
     startTime.add(1, 'd')
   }
-  task.endTime = endTime.toDate()
+  return renderEndTime
 }
 
 const getStartDate = function (prevTime, dateFormat, str) {

--- a/src/diagrams/gantt/ganttDb.js
+++ b/src/diagrams/gantt/ganttDb.js
@@ -74,17 +74,20 @@ const isInvalidDate = function (date, dateFormat, excludes) {
 }
 
 const fixTaskDates = function (task, dateFormat, excludes) {
-  if (excludes.length && !task.manualEndTime) {
-    let startTime = moment(task.startTime).add(1, 'd')
-    let endTime = moment(task.endTime)
-    while (startTime.date() <= endTime.date()) {
-      if (isInvalidDate(startTime, dateFormat, excludes)) {
-        endTime.add(1, 'd')
-      }
-      startTime.add(1, 'd')
+  if (! excludes.length || task.manualEndTime) return;
+
+  let startTime = moment(task.startTime)
+  startTime.add(1, 'd')
+  let endTime = moment(task.endTime)
+
+  while (startTime.date() <= endTime.date()) {
+    if (isInvalidDate(startTime, dateFormat, excludes)) {
+      endTime.add(1, 'd')
     }
-    task.endTime = endTime.toDate()
+    startTime.add(1, 'd')
   }
+  
+  task.endTime = endTime.toDate()
 }
 
 const getStartDate = function (prevTime, dateFormat, str) {

--- a/src/diagrams/gantt/ganttDb.js
+++ b/src/diagrams/gantt/ganttDb.js
@@ -78,8 +78,13 @@ const fixTaskDates = function (task, dateFormat, excludes) {
   let startTime = moment(task.startTime)
   startTime.add(1, 'd')
   let endTime = moment(task.endTime)
+  let invalid = false
   while (startTime.date() <= endTime.date()) {
-    if (isInvalidDate(startTime, dateFormat, excludes)) {
+    if (!invalid) {
+      task.renderEndTime = endTime.toDate()
+    }
+    invalid = isInvalidDate(startTime, dateFormat, excludes)
+    if (invalid) {
       endTime.add(1, 'd')
     }
     startTime.add(1, 'd')
@@ -308,6 +313,7 @@ export const addTask = function (descr, data) {
     type: currentSection,
     processed: false,
     manualEndTime: false,
+    renderEndTime: null,
     raw: { data: data },
     task: descr
   }

--- a/src/diagrams/gantt/ganttDb.js
+++ b/src/diagrams/gantt/ganttDb.js
@@ -64,13 +64,19 @@ export const getTasks = function () {
 }
 
 const getNextValidDate = function (date, dateFormat, excludes) {
-  const excludeWeekends = excludes.indexOf('weekend') >= 0 || excludes.indexOf('weekends') >= 0;
+  const excludeWeekends = excludes.indexOf('weekend') >= 0 || excludes.indexOf('weekends') >= 0
   const trimmedDateFormat = dateFormat.trim()
-  let mDate = moment.isMoment(date) ? date : (moment.isDate(date) ? moment(date) : moment(date, dateFormat, true));
-  while ((excludeWeekends && mDate.isoWeekday() >= 6) || (excludes.indexOf(mDate.format(trimmedDateFormat)) >= 0)) {
+  let mDate = moment.isMoment(date) ? date : (moment.isDate(date) ? moment(date) : moment(date, dateFormat, true))
+
+  const isInvalidDate = function (d) {
+    return (excludeWeekends && d.isoWeekday() >= 6) || (excludes.indexOf(d.format(trimmedDateFormat)) >= 0)
+  }
+
+  while (isInvalidDate(mDate)) {
     mDate = mDate.add(1, 'd')
   }
-  return mDate.toDate();
+
+  return mDate.toDate()
 }
 
 const getStartDate = function (prevTime, dateFormat, excludes, str) {
@@ -86,15 +92,15 @@ const getStartDate = function (prevTime, dateFormat, excludes, str) {
     if (typeof task === 'undefined') {
       const dt = new Date()
       dt.setHours(0, 0, 0, 0)
-      //return getNextValidDate(dt, dateFormat, excludes)
+      // return getNextValidDate(dt, dateFormat, excludes)
       return dt
     }
-    //return getNextValidDate(task.endTime, dateFormat, excludes)
+    // return getNextValidDate(task.endTime, dateFormat, excludes)
     return task.endTime
   }
 
   // Check for actual date set
-  let mDate = moment(str, dateFormat.trim(), true);
+  let mDate = moment(str, dateFormat.trim(), true)
   if (mDate.isValid()) {
     return getNextValidDate(mDate, dateFormat, excludes)
   } else {
@@ -110,9 +116,9 @@ const getEndDate = function (prevTime, dateFormat, excludes, str) {
   str = str.trim()
 
   // Check for actual date
-  let mDate = moment(str, dateFormat.trim(), true);
+  let mDate = moment(str, dateFormat.trim(), true)
   if (mDate.isValid()) {
-    //return getNextValidDate(mDate, dateFormat, excludes)
+    // return getNextValidDate(mDate, dateFormat, excludes)
     return mDate.toDate()
   }
 

--- a/src/diagrams/gantt/ganttDb.js
+++ b/src/diagrams/gantt/ganttDb.js
@@ -73,8 +73,12 @@ const isInvalidDate = function (date, dateFormat, excludes) {
   return excludes.indexOf(date.format(dateFormat.trim())) >= 0
 }
 
-const fixTaskDates = function (task, dateFormat, excludes) {
+const checkTaskDates = function (task, dateFormat, excludes) {
   if (!excludes.length || task.manualEndTime) return
+  fixTaskDates(task, dateFormat, excludes)
+}
+
+const fixTaskDates = function (task, dateFormat, excludes) {
   let startTime = moment(task.startTime)
   startTime.add(1, 'd')
   let endTime = moment(task.endTime)
@@ -239,7 +243,7 @@ const compileData = function (prevTask, dataStr) {
   if (endTimeData) {
     task.endTime = getEndDate(task.startTime, dateFormat, endTimeData)
     task.manualEndTime = endTimeData === moment(task.endTime).format(dateFormat.trim())
-    fixTaskDates(task, dateFormat, excludes)
+    checkTaskDates(task, dateFormat, excludes)
   }
 
   return task
@@ -378,7 +382,7 @@ const compileTasks = function () {
       if (rawTasks[pos].endTime) {
         rawTasks[pos].processed = true
         rawTasks[pos].manualEndTime = rawTasks[pos].raw.endTime.data === moment(rawTasks[pos].endTime).format(dateFormat.trim())
-        fixTaskDates(rawTasks[pos], dateFormat, excludes)
+        checkTaskDates(rawTasks[pos], dateFormat, excludes)
       }
     }
 

--- a/src/diagrams/gantt/ganttDb.js
+++ b/src/diagrams/gantt/ganttDb.js
@@ -64,9 +64,10 @@ export const getTasks = function () {
 }
 
 const isInvalidDate = function (date, dateFormat, excludes) {
-  if (date.isoWeekday() >= 6 && excludes.indexOf('weekends') >= 0)
-    return true;
-  return excludes.indexOf(date.format(dateFormat.trim())) >= 0;
+  if (date.isoWeekday() >= 6 && excludes.indexOf('weekends') >= 0) {
+    return true
+  }
+  return excludes.indexOf(date.format(dateFormat.trim())) >= 0
 }
 
 const getNextValidDate = function (date, dateFormat, excludes) {

--- a/src/diagrams/gantt/ganttDb.spec.js
+++ b/src/diagrams/gantt/ganttDb.spec.js
@@ -174,16 +174,40 @@ describe('when using the ganttDb', function () {
   })
   it('should ignore weekends', function () {
     ganttDb.setDateFormat('YYYY-MM-DD')
-    ganttDb.setExcludes('weekends 2019-02-06')
+    ganttDb.setExcludes('weekends 2019-02-06,friday')
     ganttDb.addSection('testa1')
     ganttDb.addTask('test1', 'id1,2019-02-01,1d')
-    ganttDb.addTask('test2', 'id2,after id1,3d')
+    ganttDb.addTask('test2', 'id2,after id1,2d')
+    ganttDb.addTask('test3', 'id3,after id2,7d')
+    ganttDb.addTask('test4', 'id4,2019-02-01,2019-02-20') // Fixed endTime
+    ganttDb.addTask('test5', 'id5,after id4,1d')
 
     const tasks = ganttDb.getTasks()
+
+    expect(tasks[0].startTime).toEqual(moment('2019-02-01', 'YYYY-MM-DD').toDate())
+    expect(tasks[0].endTime).toEqual(moment('2019-02-04', 'YYYY-MM-DD').toDate())
+    expect(tasks[0].id).toEqual('id1')
+    expect(tasks[0].task).toEqual('test1')
 
     expect(tasks[1].startTime).toEqual(moment('2019-02-04', 'YYYY-MM-DD').toDate())
     expect(tasks[1].endTime).toEqual(moment('2019-02-07', 'YYYY-MM-DD').toDate())
     expect(tasks[1].id).toEqual('id2')
     expect(tasks[1].task).toEqual('test2')
+
+    expect(tasks[2].startTime).toEqual(moment('2019-02-07', 'YYYY-MM-DD').toDate())
+    expect(tasks[2].endTime).toEqual(moment('2019-02-20', 'YYYY-MM-DD').toDate())
+    expect(tasks[2].id).toEqual('id3')
+    expect(tasks[2].task).toEqual('test3')
+
+    expect(tasks[3].startTime).toEqual(moment('2019-02-01', 'YYYY-MM-DD').toDate())
+    expect(tasks[3].endTime).toEqual(moment('2019-02-20', 'YYYY-MM-DD').toDate())
+    expect(tasks[3].id).toEqual('id4')
+    expect(tasks[3].task).toEqual('test4')
+
+    expect(tasks[4].startTime).toEqual(moment('2019-02-20', 'YYYY-MM-DD').toDate())
+    expect(tasks[4].endTime).toEqual(moment('2019-02-21', 'YYYY-MM-DD').toDate())
+    expect(tasks[4].id).toEqual('id5')
+    expect(tasks[4].task).toEqual('test5')
+    
   })
 })

--- a/src/diagrams/gantt/ganttDb.spec.js
+++ b/src/diagrams/gantt/ganttDb.spec.js
@@ -175,38 +175,57 @@ describe('when using the ganttDb', function () {
   it('should ignore weekends', function () {
     ganttDb.setDateFormat('YYYY-MM-DD')
     ganttDb.setExcludes('weekends 2019-02-06,friday')
-    ganttDb.addSection('testa1')
+    ganttDb.addSection('weekends skip test')
     ganttDb.addTask('test1', 'id1,2019-02-01,1d')
     ganttDb.addTask('test2', 'id2,after id1,2d')
     ganttDb.addTask('test3', 'id3,after id2,7d')
     ganttDb.addTask('test4', 'id4,2019-02-01,2019-02-20') // Fixed endTime
     ganttDb.addTask('test5', 'id5,after id4,1d')
+    ganttDb.addSection('full ending taks on last day')
+    ganttDb.addTask('test6', 'id6,2019-02-13,2d')
+    ganttDb.addTask('test7', 'id7,after id6,1d')
 
     const tasks = ganttDb.getTasks()
 
     expect(tasks[0].startTime).toEqual(moment('2019-02-01', 'YYYY-MM-DD').toDate())
     expect(tasks[0].endTime).toEqual(moment('2019-02-04', 'YYYY-MM-DD').toDate())
+    expect(tasks[0].renderEndTime).toEqual(moment('2019-02-02', 'YYYY-MM-DD').toDate())
     expect(tasks[0].id).toEqual('id1')
     expect(tasks[0].task).toEqual('test1')
 
     expect(tasks[1].startTime).toEqual(moment('2019-02-04', 'YYYY-MM-DD').toDate())
     expect(tasks[1].endTime).toEqual(moment('2019-02-07', 'YYYY-MM-DD').toDate())
+    expect(tasks[1].renderEndTime).toEqual(moment('2019-02-06', 'YYYY-MM-DD').toDate())
     expect(tasks[1].id).toEqual('id2')
     expect(tasks[1].task).toEqual('test2')
 
     expect(tasks[2].startTime).toEqual(moment('2019-02-07', 'YYYY-MM-DD').toDate())
     expect(tasks[2].endTime).toEqual(moment('2019-02-20', 'YYYY-MM-DD').toDate())
+    expect(tasks[2].renderEndTime).toEqual(moment('2019-02-20', 'YYYY-MM-DD').toDate())
     expect(tasks[2].id).toEqual('id3')
     expect(tasks[2].task).toEqual('test3')
 
     expect(tasks[3].startTime).toEqual(moment('2019-02-01', 'YYYY-MM-DD').toDate())
     expect(tasks[3].endTime).toEqual(moment('2019-02-20', 'YYYY-MM-DD').toDate())
+    expect(tasks[3].renderEndTime).toBeNull() // Fixed end
     expect(tasks[3].id).toEqual('id4')
     expect(tasks[3].task).toEqual('test4')
 
     expect(tasks[4].startTime).toEqual(moment('2019-02-20', 'YYYY-MM-DD').toDate())
     expect(tasks[4].endTime).toEqual(moment('2019-02-21', 'YYYY-MM-DD').toDate())
+    expect(tasks[4].renderEndTime).toEqual(moment('2019-02-21', 'YYYY-MM-DD').toDate())
     expect(tasks[4].id).toEqual('id5')
     expect(tasks[4].task).toEqual('test5')
+
+    expect(tasks[5].startTime).toEqual(moment('2019-02-13', 'YYYY-MM-DD').toDate())
+    expect(tasks[5].endTime).toEqual(moment('2019-02-18', 'YYYY-MM-DD').toDate())
+    expect(tasks[5].renderEndTime).toEqual(moment('2019-02-15', 'YYYY-MM-DD').toDate())
+    expect(tasks[5].id).toEqual('id6')
+    expect(tasks[5].task).toEqual('test6')
+
+    expect(tasks[6].startTime).toEqual(moment('2019-02-18', 'YYYY-MM-DD').toDate())
+    expect(tasks[6].endTime).toEqual(moment('2019-02-19', 'YYYY-MM-DD').toDate())
+    expect(tasks[6].id).toEqual('id7')
+    expect(tasks[6].task).toEqual('test7')
   })
 })

--- a/src/diagrams/gantt/ganttDb.spec.js
+++ b/src/diagrams/gantt/ganttDb.spec.js
@@ -208,6 +208,5 @@ describe('when using the ganttDb', function () {
     expect(tasks[4].endTime).toEqual(moment('2019-02-21', 'YYYY-MM-DD').toDate())
     expect(tasks[4].id).toEqual('id5')
     expect(tasks[4].task).toEqual('test5')
-    
   })
 })

--- a/src/diagrams/gantt/ganttDb.spec.js
+++ b/src/diagrams/gantt/ganttDb.spec.js
@@ -172,4 +172,18 @@ describe('when using the ganttDb', function () {
     expect(tasks[2].startTime).toEqual(moment('2013-01-15', 'YYYY-MM-DD').toDate())
     expect(tasks[2].endTime).toEqual(moment('2013-01-17', 'YYYY-MM-DD').toDate())
   })
+  it('should ignore weekends', function () {
+    ganttDb.setDateFormat('YYYY-MM-DD')
+    ganttDb.setExcludes('weekends 2019-02-06')
+    ganttDb.addSection('testa1')
+    ganttDb.addTask('test1', 'id1,2019-02-01,1d')
+    ganttDb.addTask('test2', 'id2,after id1,3d')
+
+    const tasks = ganttDb.getTasks()
+
+    expect(tasks[1].startTime).toEqual(moment('2019-02-04', 'YYYY-MM-DD').toDate())
+    expect(tasks[1].endTime).toEqual(moment('2019-02-07', 'YYYY-MM-DD').toDate())
+    expect(tasks[1].id).toEqual('id2')
+    expect(tasks[1].task).toEqual('test2')
+  })
 })

--- a/src/diagrams/gantt/ganttRenderer.js
+++ b/src/diagrams/gantt/ganttRenderer.js
@@ -135,7 +135,7 @@ export const draw = function (text, id) {
         return i * theGap + theTopPad
       })
       .attr('width', function (d) {
-        return (timeScale(d.endTime) - timeScale(d.startTime))
+        return (timeScale(d.renderEndTime || d.endTime) - timeScale(d.startTime))
       })
       .attr('height', theBarHeight)
       .attr('class', function (d) {
@@ -178,7 +178,7 @@ export const draw = function (text, id) {
       .attr('font-size', conf.fontSize)
       .attr('x', function (d) {
         const startX = timeScale(d.startTime)
-        const endX = timeScale(d.endTime)
+        const endX = timeScale(d.renderEndTime || d.endTime)
         const textWidth = this.getBBox().width
 
         // Check id text width > width of rectangle

--- a/src/diagrams/gantt/parser/gantt.jison
+++ b/src/diagrams/gantt/parser/gantt.jison
@@ -20,14 +20,15 @@
 "gantt"     	        return 'gantt';
 "dateFormat"\s[^#\n;]+  return 'dateFormat';
 "axisFormat"\s[^#\n;]+  return 'axisFormat';
+"excludes"\s[^#\n;]+    return 'excludes';
 \d\d\d\d"-"\d\d"-"\d\d  return 'date';
 "title"\s[^#\n;]+       return 'title';
 "section"\s[^#:\n;]+    return 'section';
 [^#:\n;]+               return 'taskTxt';
 ":"[^#\n;]+             return 'taskData';
-":"                         return ':';
-<<EOF>>                     return 'EOF';
-.                           return 'INVALID';
+":"                     return ':';
+<<EOF>>                 return 'EOF';
+.                       return 'INVALID';
 
 /lex
 
@@ -56,6 +57,7 @@ line
 statement
 	: 'dateFormat' {yy.setDateFormat($1.substr(11));$$=$1.substr(11);}
   | 'axisFormat' {yy.setAxisFormat($1.substr(11));$$=$1.substr(11);}
+  | 'excludes' {yy.setExcludes($1.substr(9));$$=$1.substr(9);}
 	| title {yy.setTitle($1.substr(6));$$=$1.substr(6);}
 	| section {yy.addSection($1.substr(8));$$=$1.substr(8);}
 	| taskTxt taskData {yy.addTask($1,$2);$$='task';}

--- a/src/diagrams/gantt/parser/gantt.js
+++ b/src/diagrams/gantt/parser/gantt.js
@@ -72,12 +72,12 @@
   }
 */
 var parser = (function(){
-var o=function(k,v,o,l){for(o=o||{},l=k.length;l--;o[k[l]]=v);return o},$V0=[6,8,10,11,12,13,14,15],$V1=[1,9],$V2=[1,10],$V3=[1,11],$V4=[1,12],$V5=[1,13];
-var parser = {trace: function trace () { },
+var o=function(k,v,o,l){for(o=o||{},l=k.length;l--;o[k[l]]=v);return o},$V0=[6,8,10,11,12,13,14,15,16],$V1=[1,9],$V2=[1,10],$V3=[1,11],$V4=[1,12],$V5=[1,13],$V6=[1,14];
+var parser = {trace: function trace() { },
 yy: {},
-symbols_: {"error":2,"start":3,"gantt":4,"document":5,"EOF":6,"line":7,"SPACE":8,"statement":9,"NL":10,"dateFormat":11,"axisFormat":12,"title":13,"section":14,"taskTxt":15,"taskData":16,"$accept":0,"$end":1},
-terminals_: {2:"error",4:"gantt",6:"EOF",8:"SPACE",10:"NL",11:"dateFormat",12:"axisFormat",13:"title",14:"section",15:"taskTxt",16:"taskData"},
-productions_: [0,[3,3],[5,0],[5,2],[7,2],[7,1],[7,1],[7,1],[9,1],[9,1],[9,1],[9,1],[9,2]],
+symbols_: {"error":2,"start":3,"gantt":4,"document":5,"EOF":6,"line":7,"SPACE":8,"statement":9,"NL":10,"dateFormat":11,"axisFormat":12,"excludes":13,"title":14,"section":15,"taskTxt":16,"taskData":17,"$accept":0,"$end":1},
+terminals_: {2:"error",4:"gantt",6:"EOF",8:"SPACE",10:"NL",11:"dateFormat",12:"axisFormat",13:"excludes",14:"title",15:"section",16:"taskTxt",17:"taskData"},
+productions_: [0,[3,3],[5,0],[5,2],[7,2],[7,1],[7,1],[7,1],[9,1],[9,1],[9,1],[9,1],[9,1],[9,2]],
 performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate /* action[1] */, $$ /* vstack */, _$ /* lstack */) {
 /* this == yyval */
 
@@ -105,19 +105,22 @@ case 9:
 yy.setAxisFormat($$[$0].substr(11));this.$=$$[$0].substr(11);
 break;
 case 10:
-yy.setTitle($$[$0].substr(6));this.$=$$[$0].substr(6);
+yy.setExcludes($$[$0].substr(9));this.$=$$[$0].substr(9);
 break;
 case 11:
-yy.addSection($$[$0].substr(8));this.$=$$[$0].substr(8);
+yy.setTitle($$[$0].substr(6));this.$=$$[$0].substr(6);
 break;
 case 12:
+yy.addSection($$[$0].substr(8));this.$=$$[$0].substr(8);
+break;
+case 13:
 yy.addTask($$[$0-1],$$[$0]);this.$='task';
 break;
 }
 },
-table: [{3:1,4:[1,2]},{1:[3]},o($V0,[2,2],{5:3}),{6:[1,4],7:5,8:[1,6],9:7,10:[1,8],11:$V1,12:$V2,13:$V3,14:$V4,15:$V5},o($V0,[2,7],{1:[2,1]}),o($V0,[2,3]),{9:14,11:$V1,12:$V2,13:$V3,14:$V4,15:$V5},o($V0,[2,5]),o($V0,[2,6]),o($V0,[2,8]),o($V0,[2,9]),o($V0,[2,10]),o($V0,[2,11]),{16:[1,15]},o($V0,[2,4]),o($V0,[2,12])],
+table: [{3:1,4:[1,2]},{1:[3]},o($V0,[2,2],{5:3}),{6:[1,4],7:5,8:[1,6],9:7,10:[1,8],11:$V1,12:$V2,13:$V3,14:$V4,15:$V5,16:$V6},o($V0,[2,7],{1:[2,1]}),o($V0,[2,3]),{9:15,11:$V1,12:$V2,13:$V3,14:$V4,15:$V5,16:$V6},o($V0,[2,5]),o($V0,[2,6]),o($V0,[2,8]),o($V0,[2,9]),o($V0,[2,10]),o($V0,[2,11]),o($V0,[2,12]),{17:[1,16]},o($V0,[2,4]),o($V0,[2,13])],
 defaultActions: {},
-parseError: function parseError (str, hash) {
+parseError: function parseError(str, hash) {
     if (hash.recoverable) {
         this.trace(str);
     } else {
@@ -409,7 +412,7 @@ showPosition:function () {
     },
 
 // test the lexed token: return FALSE when not a match, otherwise return token
-test_match:function(match, indexed_rule) {
+test_match:function (match, indexed_rule) {
         var token,
             lines,
             backup;
@@ -539,7 +542,7 @@ next:function () {
     },
 
 // return next match that has a token
-lex:function lex () {
+lex:function lex() {
         var r = this.next();
         if (r) {
             return r;
@@ -549,12 +552,12 @@ lex:function lex () {
     },
 
 // activates a new lexer condition state (pushes the new lexer condition state onto the condition stack)
-begin:function begin (condition) {
+begin:function begin(condition) {
         this.conditionStack.push(condition);
     },
 
 // pop the previously active lexer condition state off the condition stack
-popState:function popState () {
+popState:function popState() {
         var n = this.conditionStack.length - 1;
         if (n > 0) {
             return this.conditionStack.pop();
@@ -564,7 +567,7 @@ popState:function popState () {
     },
 
 // produce the lexer rule set which is active for the currently active lexer condition state
-_currentRules:function _currentRules () {
+_currentRules:function _currentRules() {
         if (this.conditionStack.length && this.conditionStack[this.conditionStack.length - 1]) {
             return this.conditions[this.conditionStack[this.conditionStack.length - 1]].rules;
         } else {
@@ -573,7 +576,7 @@ _currentRules:function _currentRules () {
     },
 
 // return the currently active lexer condition state; when an index argument is provided it produces the N-th previous condition state, if available
-topState:function topState (n) {
+topState:function topState(n) {
         n = this.conditionStack.length - 1 - Math.abs(n || 0);
         if (n >= 0) {
             return this.conditionStack[n];
@@ -583,7 +586,7 @@ topState:function topState (n) {
     },
 
 // alias for begin(condition)
-pushState:function pushState (condition) {
+pushState:function pushState(condition) {
         this.begin(condition);
     },
 
@@ -611,9 +614,9 @@ case 5:return 11;
 break;
 case 6:return 12;
 break;
-case 7:return 'date';
+case 7:return 13;
 break;
-case 8:return 13;
+case 8:return 'date';
 break;
 case 9:return 14;
 break;
@@ -621,16 +624,18 @@ case 10:return 15;
 break;
 case 11:return 16;
 break;
-case 12:return ':';
+case 12:return 17;
 break;
-case 13:return 6;
+case 13:return ':';
 break;
-case 14:return 'INVALID';
+case 14:return 6;
+break;
+case 15:return 'INVALID';
 break;
 }
 },
-rules: [/^(?:[\n]+)/i,/^(?:\s+)/i,/^(?:#[^\n]*)/i,/^(?:%[^\n]*)/i,/^(?:gantt\b)/i,/^(?:dateFormat\s[^#\n;]+)/i,/^(?:axisFormat\s[^#\n;]+)/i,/^(?:\d\d\d\d-\d\d-\d\d\b)/i,/^(?:title\s[^#\n;]+)/i,/^(?:section\s[^#:\n;]+)/i,/^(?:[^#:\n;]+)/i,/^(?::[^#\n;]+)/i,/^(?::)/i,/^(?:$)/i,/^(?:.)/i],
-conditions: {"INITIAL":{"rules":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14],"inclusive":true}}
+rules: [/^(?:[\n]+)/i,/^(?:\s+)/i,/^(?:#[^\n]*)/i,/^(?:%[^\n]*)/i,/^(?:gantt\b)/i,/^(?:dateFormat\s[^#\n;]+)/i,/^(?:axisFormat\s[^#\n;]+)/i,/^(?:excludes\s[^#\n;]+)/i,/^(?:\d\d\d\d-\d\d-\d\d\b)/i,/^(?:title\s[^#\n;]+)/i,/^(?:section\s[^#:\n;]+)/i,/^(?:[^#:\n;]+)/i,/^(?::[^#\n;]+)/i,/^(?::)/i,/^(?:$)/i,/^(?:.)/i],
+conditions: {"INITIAL":{"rules":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],"inclusive":true}}
 });
 return lexer;
 })();
@@ -647,7 +652,7 @@ if (typeof require !== 'undefined' && typeof exports !== 'undefined') {
 exports.parser = parser;
 exports.Parser = parser.Parser;
 exports.parse = function () { return parser.parse.apply(parser, arguments); };
-exports.main = function commonjsMain (args) {
+exports.main = function commonjsMain(args) {
     if (!args[1]) {
         console.log('Usage: '+args[0]+' FILE');
         process.exit(1);


### PR DESCRIPTION
Added: exclude weekdays [and a list of specific dates] on Gantt.

As mentioned on issue #314 

It is open to discussion how to render this:
1. Keep this way. Extending the weekends or excluded days;
2. Hide the ignored dates;
3. Indicate the ignored dates on the task rectangle in some way.

But I think it can be handled on another issue if anyone needs it.