### PR TITLE
Fix issue with XML line breaks inside vertex labels

### DIFF
--- a/src/diagrams/flowchart/flowRenderer.js
+++ b/src/diagrams/flowchart/flowRenderer.js
@@ -203,7 +203,7 @@ export const addEdges = function (edges, g) {
           edgeData.label = '<span class="edgeLabel">' + edge.text + '</span>'
         } else {
           edgeData.labelType = 'text'
-          edgeData.style = 'stroke: #333; stroke-width: 1.5px;fill:none'
+          edgeData.style = edgeData.style || 'stroke: #333; stroke-width: 1.5px;fill:none'
           edgeData.label = edge.text.replace(/<br>/g, '\n')
         }
       } else {

--- a/src/diagrams/flowchart/flowRenderer.js
+++ b/src/diagrams/flowchart/flowRenderer.js
@@ -74,7 +74,7 @@ export const addVertices = function (vert, g) {
     } else {
       const svgLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text')
 
-      const rows = verticeText.split(/<br>/)
+      const rows = verticeText.split(/<br[\/]{0,1}>/)
 
       for (let j = 0; j < rows.length; j++) {
         const tspan = document.createElementNS('http://www.w3.org/2000/svg', 'tspan')

--- a/src/diagrams/flowchart/flowRenderer.js
+++ b/src/diagrams/flowchart/flowRenderer.js
@@ -74,7 +74,7 @@ export const addVertices = function (vert, g) {
     } else {
       const svgLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text')
 
-      const rows = verticeText.split(/<br[\/]{0,1}>/)
+      const rows = verticeText.split(/<br[/]{0,1}>/)
 
       for (let j = 0; j < rows.length; j++) {
         const tspan = document.createElementNS('http://www.w3.org/2000/svg', 'tspan')


### PR DESCRIPTION
The regex needed to match the `<br>` or `<br/>` wasn't completely correct as there is an attempt to turn `<br>` elements into their XHTML counter-parts `<br/>` later in the flowRenderer sequence. This fixes the regex so both will match.

You can test this yourself with this MMD file:

```
graph LR

ap[Admin Web App]
hs[Host Server]
pa{Platform<br>Administrator}

pa --- |manages accounts| ap
ap --- |syncs accounts| hs
```

### Without fix:
![without-fix](https://user-images.githubusercontent.com/601346/56391689-4e650280-6227-11e9-9507-d85fe2d0a7e0.png)

### With fix
![with-fix](https://user-images.githubusercontent.com/601346/56391700-59b82e00-6227-11e9-8f06-72cc3328832a.png)
