### PR TITLE
Fix dotted lines not appearing in flowcharts when HTML labels disabled

### DIFF
--- a/src/diagrams/flowchart/flowRenderer.js
+++ b/src/diagrams/flowchart/flowRenderer.js
@@ -203,7 +203,6 @@ export const addEdges = function (edges, g) {
           edgeData.label = '<span class="edgeLabel">' + edge.text + '</span>'
         } else {
           edgeData.labelType = 'text'
-          edgeData.style = 'stroke: #333; stroke-width: 1.5px;fill:none'
           edgeData.label = edge.text.replace(/<br>/g, '\n')
         }
       } else {


### PR DESCRIPTION
For some reason, `edgeData.style` was being overwritten when it
was already set earlier in the method.