### PR TITLE
fix draw function can only call once

### DIFF
--- a/src/diagrams/class/classRenderer.js
+++ b/src/diagrams/class/classRenderer.js
@@ -8,7 +8,7 @@ import { parser } from './parser/classDiagram'
 
 parser.yy = classDb
 
-const idCache = {}
+let idCache = {}
 
 let classCnt = 0
 const conf = {
@@ -301,6 +301,7 @@ export const setConf = function (cnf) {
  * @param id
  */
 export const draw = function (text, id) {
+  idCache = {}
   parser.yy.clear()
   parser.parse(text)
 


### PR DESCRIPTION
After working around the first problem was, that the diagram was only rendered the first time. Each time after that cannot read property x of undefined occurred.

I fix this bug. `idCache` not clear when then next draw.

fix #748