### PR TITLE
Significantly smaller bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,7 @@
     "dagre-layout": "^0.8.8",
     "graphlibrary": "^2.2.0",
     "he": "^1.2.0",
-    "lodash.assign": "^4.2.0",
-    "lodash.maxby": "^4.6.0",
-    "lodash.orderby": "^4.6.0",
-    "lodash.uniqby": "^4.7.0",
+    "lodash": "^4.17.5",
     "moment-mini": "^2.22.1",
     "scope-css": "^1.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -72,8 +72,7 @@
     "yarn-upgrade-all": "^0.5.0"
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "jest": {
     "moduleNameMapper": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "graphlibrary": "^2.2.0",
     "he": "^1.2.0",
     "lodash": "^4.17.11",
-    "moment": "^2.23.0",
+    "moment-mini": "^2.22.1",
     "scope-css": "^1.2.1"
   },
   "devDependencies": {
@@ -62,6 +62,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^23.6.0",
     "jison": "^0.4.18",
+    "moment": "^2.23.0",
     "node-sass": "^4.11.0",
     "sass-loader": "^7.1.0",
     "standard": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,10 @@
     "dagre-layout": "^0.8.8",
     "graphlibrary": "^2.2.0",
     "he": "^1.2.0",
-    "lodash": "^4.17.11",
+    "lodash.assign": "^4.2.0",
+    "lodash.maxby": "^4.6.0",
+    "lodash.orderby": "^4.6.0",
+    "lodash.uniqby": "^4.7.0",
     "moment-mini": "^2.22.1",
     "scope-css": "^1.2.1"
   },

--- a/src/diagrams/gantt/ganttDb.js
+++ b/src/diagrams/gantt/ganttDb.js
@@ -1,4 +1,4 @@
-import moment from 'moment'
+import moment from 'moment-mini'
 import { logger } from '../../logger'
 
 let dateFormat = ''

--- a/src/diagrams/git/gitGraphAst.js
+++ b/src/diagrams/git/gitGraphAst.js
@@ -1,6 +1,4 @@
-import maxBy from 'lodash.maxby'
-import orderBy from 'lodash.orderby'
-import uniqBy from 'lodash.uniqby'
+import _ from 'lodash'
 
 import { logger } from '../../logger'
 
@@ -147,7 +145,7 @@ function upsert (arr, key, newval) {
 }
 
 function prettyPrintCommitHistory (commitArr) {
-  const commit = maxBy(commitArr, 'seq')
+  const commit = _.maxBy(commitArr, 'seq')
   let line = ''
   commitArr.forEach(function (c) {
     if (c === commit) {
@@ -171,7 +169,7 @@ function prettyPrintCommitHistory (commitArr) {
     const nextCommit = commits[commit.parent]
     upsert(commitArr, commit, nextCommit)
   }
-  commitArr = uniqBy(commitArr, 'id')
+  commitArr = _.uniqBy(commitArr, 'id')
   prettyPrintCommitHistory(commitArr)
 }
 
@@ -204,7 +202,7 @@ export const getCommitsArray = function () {
     return commits[key]
   })
   commitArr.forEach(function (o) { logger.debug(o.id) })
-  return orderBy(commitArr, ['seq'], ['desc'])
+  return _.orderBy(commitArr, ['seq'], ['desc'])
 }
 export const getCurrentBranch = function () { return curBranch }
 export const getDirection = function () { return direction }

--- a/src/diagrams/git/gitGraphAst.js
+++ b/src/diagrams/git/gitGraphAst.js
@@ -1,4 +1,6 @@
-import _ from 'lodash'
+import maxBy from 'lodash.maxby'
+import orderBy from 'lodash.orderby'
+import uniqBy from 'lodash.uniqby'
 
 import { logger } from '../../logger'
 
@@ -145,7 +147,7 @@ function upsert (arr, key, newval) {
 }
 
 function prettyPrintCommitHistory (commitArr) {
-  const commit = _.maxBy(commitArr, 'seq')
+  const commit = maxBy(commitArr, 'seq')
   let line = ''
   commitArr.forEach(function (c) {
     if (c === commit) {
@@ -155,9 +157,9 @@ function prettyPrintCommitHistory (commitArr) {
     }
   })
   const label = [line, commit.id, commit.seq]
-  _.each(branches, function (value, key) {
-    if (value === commit.id) label.push(key)
-  })
+  for (let branch in branches) {
+    if (branches[branch] === commit.id) label.push(branch)
+  }
   logger.debug(label.join(' '))
   if (Array.isArray(commit.parent)) {
     const newCommit = commits[commit.parent[0]]
@@ -169,7 +171,7 @@ function prettyPrintCommitHistory (commitArr) {
     const nextCommit = commits[commit.parent]
     upsert(commitArr, commit, nextCommit)
   }
-  commitArr = _.uniqBy(commitArr, 'id')
+  commitArr = uniqBy(commitArr, 'id')
   prettyPrintCommitHistory(commitArr)
 }
 
@@ -188,9 +190,10 @@ export const clear = function () {
 }
 
 export const getBranchesAsObjArray = function () {
-  const branchArr = _.map(branches, function (value, key) {
-    return { 'name': key, 'commit': commits[value] }
-  })
+  const branchArr = []
+  for (let branch in branches) {
+    branchArr.push({ name: branch, commit: commits[branches[branch]] })
+  }
   return branchArr
 }
 
@@ -201,7 +204,7 @@ export const getCommitsArray = function () {
     return commits[key]
   })
   commitArr.forEach(function (o) { logger.debug(o.id) })
-  return _.orderBy(commitArr, ['seq'], ['desc'])
+  return orderBy(commitArr, ['seq'], ['desc'])
 }
 export const getCurrentBranch = function () { return curBranch }
 export const getDirection = function () { return direction }

--- a/src/diagrams/git/gitGraphRenderer.js
+++ b/src/diagrams/git/gitGraphRenderer.js
@@ -1,5 +1,5 @@
 import * as d3 from 'd3'
-import assign from 'lodash.assign'
+import _ from 'lodash'
 
 import db from './gitGraphAst'
 import gitGraphParser from './parser/gitGraph'
@@ -252,7 +252,7 @@ export const draw = function (txt, id, ver) {
     // Parse the graph definition
     parser.parse(txt + '\n')
 
-    config = assign(config, apiConfig, db.getOptions())
+    config = _.assign(config, apiConfig, db.getOptions())
     logger.debug('effective options', config)
     const direction = db.getDirection()
     allCommitsDict = db.getCommits()

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,4 +1,4 @@
-import moment from 'moment'
+import moment from 'moment-mini'
 
 export const LEVELS = {
   debug: 1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5539,10 +5539,15 @@ mixin-object@^2.0.1:
   dependencies:
     minimist "0.0.8"
 
+moment-mini@^2.22.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/moment-mini/-/moment-mini-2.22.1.tgz#bc32d73e43a4505070be6b53494b17623183420d"
+  integrity sha512-OUCkHOz7ehtNMYuZjNciXUfwTuz8vmF1MTbAy59ebf+ZBYZO5/tZKuChVWCX+uDo+4idJBpGltNfV8st+HwsGw==
+
 moment@^2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.23.0.tgz#759ea491ac97d54bac5ad776996e2a58cc1bc225"
-  integrity sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA==
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5163,20 +5163,10 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash.maxby@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.maxby/-/lodash.maxby-4.6.0.tgz#082240068f3c7a227aa00a8380e4f38cf0786e3d"
-  integrity sha1-CCJABo88eiJ6oAqDgOTzjPB4bj0=
-
 lodash.mergewith@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
   integrity sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==
-
-lodash.orderby@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.orderby/-/lodash.orderby-4.6.0.tgz#e697f04ce5d78522f54d9338b32b81a3393e4eb3"
-  integrity sha1-5pfwTOXXhSL1TZM4syuBozk+TrM=
 
 lodash.restparam@^3.0.0:
   version "3.6.1"
@@ -5212,11 +5202,6 @@ lodash.templatesettings@^3.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
     lodash.escape "^3.0.0"
-
-lodash.uniqby@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
-  integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
 
 lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.3.0, lodash@~4.17.10:
   version "4.17.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5163,10 +5163,20 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
+lodash.maxby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.maxby/-/lodash.maxby-4.6.0.tgz#082240068f3c7a227aa00a8380e4f38cf0786e3d"
+  integrity sha1-CCJABo88eiJ6oAqDgOTzjPB4bj0=
+
 lodash.mergewith@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
   integrity sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==
+
+lodash.orderby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.orderby/-/lodash.orderby-4.6.0.tgz#e697f04ce5d78522f54d9338b32b81a3393e4eb3"
+  integrity sha1-5pfwTOXXhSL1TZM4syuBozk+TrM=
 
 lodash.restparam@^3.0.0:
   version "3.6.1"
@@ -5202,6 +5212,11 @@ lodash.templatesettings@^3.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
     lodash.escape "^3.0.0"
+
+lodash.uniqby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
+  integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
 
 lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.3.0, lodash@~4.17.10:
   version "4.17.11"


### PR DESCRIPTION
Hey @knsv, I've just implemented some changes previously discussed aimed at reducing mermaid's bundled size, which is currently pretty significant. 

- I've replaced `moment` with `moment-mini`, which got rid of all the useless locale files. I'd like to switch to `dayjs` entirely, but currently `moment` is used to parse some relative date formats like `2d`, I'm not sure if that's really useful or not though.

- I've removed the `src` folder from the allowed paths being published to NPM.

- I had first reimplemented some basic lodash methods in vanilla JS and then imported only the specific non trivial ones, which reduced the bundle size, but then I noticed that another version of lodash was getting loaded by other dependencies, so later I aligned the versions so that only 1 copy of lodash get loaded (I guess this wasn't happening before because of the lock file).

The unminified bundle size went from ~4.5MB to ~2.3MB, while the minified bundle size went from ~1.4MB to ~800KB. IMHO that's a pretty significant improvement. It could be much smaller if the other libraries in our dependency tree stopped requiring the entirety of lodash, I've opened a few issues about that in their repos, let's see.

Let me know if you need any modification.

Closes #843