### PR TITLE
Fix text label colors for flow charts

### DIFF
--- a/src/diagrams/flowchart/flowRenderer.js
+++ b/src/diagrams/flowchart/flowRenderer.js
@@ -78,7 +78,6 @@ export const addVertices = function (vert, g, svgId) {
         tspan.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve')
         tspan.setAttribute('dy', '1em')
         tspan.setAttribute('x', '1')
-        tspan.setAttribute('fill', '#333')
         tspan.textContent = rows[j]
         svgLabel.appendChild(tspan)
       }

--- a/src/diagrams/flowchart/flowRenderer.js
+++ b/src/diagrams/flowchart/flowRenderer.js
@@ -78,6 +78,7 @@ export const addVertices = function (vert, g, svgId) {
         tspan.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve')
         tspan.setAttribute('dy', '1em')
         tspan.setAttribute('x', '1')
+        tspan.setAttribute('fill', '#333')
         tspan.textContent = rows[j]
         svgLabel.appendChild(tspan)
       }

--- a/src/themes/flowchart.scss
+++ b/src/themes/flowchart.scss
@@ -3,6 +3,10 @@
   color: #333;
 }
 
+.label text {
+  fill: #333;
+}
+
 .node rect,
 .node circle,
 .node ellipse,


### PR DESCRIPTION
When htmlLabels is set to `false` and a background fill color is used
for a node, the text label will inherit the fill color, hiding the
actual text. To fix this, explicitly set the fill color to `#333` in the SCSS.

Closes https://github.com/knsv/mermaid/issues/885