### PR TITLE
Fix securityLevel documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 In version 8.2 a security improvement was introduced. A securityLevel configuration was introduced which sets the level of trust to be used on the parsed diagrams.
 
-* **true**: (default) tags in text are encoded, click functionality is disabled
-* false: tags in text are allowed, click functionality is enabledClosed issues: 
+* **`strict`**: (default) tags in text are encoded, click functionality is disabled
+* `loose`: tags in text are allowed, click functionality is enabledClosed issues:
 
 ⚠️ **Note** : This changes the default behaviour of mermaid so that after upgrade to 8.2, if the securityLevel is not configured, tags in flowcharts are encoded as tags and clicking is prohibited.
 


### PR DESCRIPTION
Instead of boolean values, only `strict` and `loose` should be
used.