### PR TITLE
Close stale issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 60
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: 14
 # Issues with these labels will never be considered stale
 exemptLabels:
   - Status: Pinned
@@ -16,4 +16,6 @@ markComment: >
   for your contributions.
   If you are still interested in this issue and it is still relevant you can comment to revive it.
 # Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: false
+closeComment: >
+  This issue has been been automatically closed due to a lack of activity. 
+  This is done to maintain a clean list of issues that the community is interested in developing.


### PR DESCRIPTION
Currently, there's 267 open issues (11 pages), some of which are years old, inactive, irrelevant, etc.

This pull request aims for stale-bot to close inactive stale issues.

This will help cull the list and keep it "fresh". This will give collaborators an easier time when looking at what they can help with and lowering the bar a tiny bit for new collaborators.