### PR TITLE
Correctly document htmlLabels as true by default

### DIFF
--- a/docs/mermaidAPI.md
+++ b/docs/mermaidAPI.md
@@ -280,7 +280,7 @@ mermaidAPI.initialize({
     arrowMarkerAbsolute:false,
 
     flowchart:{
-      htmlLabels:false,
+      htmlLabels:true,
       curve:'linear',
     },
     sequence:{

--- a/src/mermaidAPI.js
+++ b/src/mermaidAPI.js
@@ -647,7 +647,7 @@ export default mermaidAPI;
  *     arrowMarkerAbsolute:false,
  *
  *     flowchart:{
- *       htmlLabels:false,
+ *       htmlLabels:true,
  *       curve:'linear',
  *     },
  *     sequence:{


### PR DESCRIPTION
The "mermaidAPI configuration defaults" section in the documentation listed `htmlLabels` as `false`, but the real default is `true`, as seen in the code and elsewhere in the documentation.