### PR TITLE
Flowchart parsing issue with CRLF #894

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -439,5 +439,18 @@ Class08 <--> C2: Cool label
       }, 100)
     }
   </script>
+  <script>
+     const testLineEndings = (test, input) => {
+       try {
+         mermaid.render(test, input, () => {});
+       } catch (err) { 
+         console.error("Error in %s:\n\n%s", test, err);
+       }
+     };
+
+     testLineEndings("CR", "graph LR\rsubgraph CR\rA --> B\rend");
+     testLineEndings("LF", "graph LR\nsubgraph LF\nA --> B\nend");
+     testLineEndings("CRLF", "graph LR\r\nsubgraph CRLF\r\nA --> B\r\nend");
+  </script>
 </body>
 </html>

--- a/src/diagrams/flowchart/parser/flow.jison
+++ b/src/diagrams/flowchart/parser/flow.jison
@@ -169,7 +169,7 @@
 "{"                   return 'DIAMOND_START'
 "}"                   return 'DIAMOND_STOP'
 "\""                  return 'QUOTE';
-\n+                   return 'NEWLINE';
+(\r|\n|\r\n)+         return 'NEWLINE';
 \s                    return 'SPACE';
 <<EOF>>               return 'EOF';
 


### PR DESCRIPTION
- modified NEWLINE regex considering MacOS (CR), Unix (LF) and Windows (CRLF) line endings
- went with the test case described in #894 and included it into dist/index.html