### PR TITLE
#783 Hard to customize font-size for gantt charts

### DIFF
--- a/src/themes/gantt.scss
+++ b/src/themes/gantt.scss
@@ -82,10 +82,12 @@
 
 .taskText {
   text-anchor: middle;
-  font-size: 11px;
   font-family: 'trebuchet ms', verdana, arial;
   font-family: var(--mermaid-font-family);
+}
 
+.taskText:not([font-size]) {
+  font-size: 11px;
 }
 
 .taskTextOutsideRight {


### PR DESCRIPTION
- deselect theme style if font-size is set on the taskText element (e.g. via gantt-config)