### PR TITLE
Added missing code snippets for trapezoid nodes in flow chart

### DIFF
--- a/docs/flowchart.md
+++ b/docs/flowchart.md
@@ -125,12 +125,20 @@ graph LR
 
 ### Trapezoid
 
+```
+graph TD
+    A[/Christmas\]
+```
 ```mermaid
 graph TD
     A[/Christmas\]
 ```
 ### Trapezoid alt
 
+```
+graph TD
+    B[\Go shopping/]
+```
 ```mermaid
 graph TD
     B[\Go shopping/]


### PR DESCRIPTION
I've found the code snippets missing when browsing the online docs - so I've added them.

Thanks for the awesome tool!