### PR TITLE
Added e2e tests to prepublish task

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dev": "webpack-dev-server --config webpack.config.e2e.js",
     "test": "yarn lint && jest src",
     "test:watch": "jest --watch src",
-    "prepublishOnly": "yarn build && yarn release && yarn test",
+    "prepublishOnly": "yarn build && yarn release && yarn test && yarn e2e",
     "prepush": "yarn test"
   },
   "repository": {


### PR DESCRIPTION
Currently, e2e tests are not executed as a part of prepublish. Before a package goes into a registry, the e2e tests should be executed.